### PR TITLE
Fix: Add exclusion marker to summarizer prompts

### DIFF
--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -78,7 +78,9 @@ export async function summarizeConversation(exchanges: ConversationExchange[], s
       ? '' // When resuming, no need to include conversation text - it's already in context
       : formatConversationText(exchanges);
 
-    const prompt = `Please write a concise, factual summary of this conversation. Output ONLY the summary - no preamble. Claude will see this summary when searching previous conversations for useful memories and information.
+    const prompt = `Context: This summary will be shown in a list to help users and Claude choose which conversations are relevant.
+
+Please write a concise, factual summary of this conversation. Output ONLY the summary - no preamble. Claude will see this summary when searching previous conversations for useful memories and information.
 
 Summarize what happened in 2-4 sentences. Be factual and specific. Output in <summary></summary> tags.
 
@@ -118,7 +120,9 @@ ${conversationText}`;
   const chunkSummaries: string[] = [];
   for (let i = 0; i < chunks.length; i++) {
     const chunkText = formatConversationText(chunks[i]);
-    const prompt = `Please write a concise summary of this part of a conversation in 2-3 sentences. What happened, what was built/discussed. Use <summary></summary> tags.
+    const prompt = `Context: This summary will be shown in a list to help users and Claude choose which conversations are relevant.
+
+Please write a concise summary of this part of a conversation in 2-3 sentences. What happened, what was built/discussed. Use <summary></summary> tags.
 
 ${chunkText}
 
@@ -139,7 +143,9 @@ Example: <summary>Implemented HID keyboard functionality for ESP32. Hit Bluetoot
   }
 
   // Synthesize chunks into final summary
-  const synthesisPrompt = `Please write a concise, factual summary that synthesizes these part-summaries into one cohesive paragraph. Focus on what was accomplished and any notable technical decisions or challenges. Output in <summary></summary> tags. Claude will see this summary when searching previous conversations for useful memories and information.
+  const synthesisPrompt = `Context: This summary will be shown in a list to help users and Claude choose which conversations are relevant.
+
+Please write a concise, factual summary that synthesizes these part-summaries into one cohesive paragraph. Focus on what was accomplished and any notable technical decisions or challenges. Output in <summary></summary> tags. Claude will see this summary when searching previous conversations for useful memories and information.
 
 Part summaries:
 ${chunkSummaries.map((s, i) => `${i + 1}. ${s}`).join('\n')}


### PR DESCRIPTION
## Problem
  Agent conversations generated by the summarizer are being indexed
   alongside real user conversations, creating noise in search
  results.

  ## Root Cause
  Commit 90da28e added exclusion markers to `sync.ts` to detect and
   skip summarization conversations, but the markers were never
  added to the actual prompts in `summarizer.ts`. This caused all
  agent-*.jsonl files to be indexed.

  ## Solution
  Added the exclusion marker text `"Context: This summary will be
  shown in a list to help users and Claude choose which
  conversations are relevant."` to all three prompts in
  `src/summarizer.ts`:
  - Main prompt (line 81)
  - Chunk prompt (line 123)
  - Synthesis prompt (line 146)

  ## Testing
  - ✅ All 71 existing tests pass
  - ✅ Manual verification: agent files now contain the marker
  - ✅ Manual verification: agent files are no longer indexed after
   sync

  ## Impact
  Agent conversations will now be properly excluded from indexing
  across all projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced summarization prompt structure with contextual instruction blocks across all summary generation stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->