### PR TITLE
Fix: Remove hook from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,6 +17,5 @@
       "args": ["${CLAUDE_PLUGIN_ROOT}/cli/mcp-server-wrapper.js"],
       "env": {}
     }
-  },
-  "hooks": "./hooks/hooks.json"
+  }
 }


### PR DESCRIPTION
This line is redundant because Claude Code
automatically loads hooks/hooks.json by
convention. By explicitly specifying it, the file
gets loaded twice.

Without the fix I get the following warning from the plugin (I have replace my home directory with $HOME below:

```
Plugin Loading Errors:

  ✘ Plugin episodic-memory from episodic-memory@superpowers-marketplace
     Failed to load hooks from $HOME/.claude/plugins/cache/episodic-memory/hooks/hooks.json: Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file
     $HOME/.claude/plugins/cache/episodic-memory/hooks/hooks.json. The standard hooks/hooks.json is loaded automatically, so manifest.hooks should only reference additional hook files.

     → Check hooks.json file syntax and structure
```

## Motivation and Context

Claude code warns that is is wrong to specify hooks in this case as the hooks are loaded twice. 

## How Has This Been Tested?
I got rid of the warning when I applied this file ~/.claude/plugins/cache/episodic-memory/.claude-plugin/plugin.json

## Breaking Changes
No. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a configuration entry from plugin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->