### PR TITLE
fix: --background flag fails silently (SessionStart hook broken)

### DIFF
--- a/cli/episodic-memory.js
+++ b/cli/episodic-memory.js
@@ -107,8 +107,8 @@ async function main() {
         break;
 
       case 'sync':
-        // Route to sync implementation
-        await runTsxCommand(join(__dirname, '../src/sync-cli.ts'), args);
+        // Route to sync implementation (using compiled version for --background compatibility)
+        await runCommand('node', [join(__dirname, '../dist/sync-cli.js'), ...args]);
         break;
 
       case '--help':


### PR DESCRIPTION
## Problem

The `--background` flag introduced in v1.0.7 fails silently, breaking the SessionStart hook's auto-sync functionality.

**Root cause:** `src/sync-cli.ts` spawns a background process using `process.execPath` (node) + `process.argv[1]` (sync-cli.ts). Node.js cannot execute TypeScript files, causing the spawned process to crash immediately with `ERR_UNKNOWN_FILE_EXTENSION`.

The error is hidden because `stdio: 'ignore'` suppresses all output.

## Solution

Route the `sync` command to use the compiled `dist/sync-cli.js` instead of `src/sync-cli.ts`, matching the pattern already used by the `index` command.

**Changed:** `cli/episodic-memory.js` line 111
```javascript
// Before:
await runTsxCommand(join(__dirname, '../src/sync-cli.ts'), args);

// After:
await runCommand('node', [join(__dirname, '../dist/sync-cli.js'), ...args]);
```

## Testing

**Before fix:**
- `episodic-memory sync --background` → Returns "Sync started in background..." but database not updated
- SessionStart hook silently fails

**After fix:**
- `episodic-memory sync --background` → Database updated successfully
- `episodic-memory sync` (without flag) → Still works correctly
- SessionStart hook functions as intended

## Impact

- **Severity:** High - Breaks primary use case (SessionStart auto-sync)
- **Affected versions:** v1.0.7, v1.0.8, v1.0.9
- **Platforms:** All (macOS, Linux, Windows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sync command execution to use precompiled JavaScript, improving performance and reliability while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->