### PR TITLE
fix(cli): use plugin node_modules for tsx instead of cwd

### DIFF
--- a/cli/episodic-memory
+++ b/cli/episodic-memory
@@ -21,22 +21,22 @@ case "$COMMAND" in
 
   search)
     # Route to search implementation
-    npx tsx "$SCRIPT_DIR/../src/search-cli.ts" "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/search-cli.ts" "$@")
     ;;
 
   show)
     # Route to show implementation
-    npx tsx "$SCRIPT_DIR/../src/show-cli.ts" "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/show-cli.ts" "$@")
     ;;
 
   stats)
     # Route to stats implementation
-    npx tsx "$SCRIPT_DIR/../src/stats-cli.ts" "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/stats-cli.ts" "$@")
     ;;
 
   sync)
     # Route to sync implementation
-    npx tsx "$SCRIPT_DIR/../src/sync-cli.ts" "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/sync-cli.ts" "$@")
     ;;
 
   --help|-h|"")


### PR DESCRIPTION
## Summary

Fixes SessionStart hook errors when using the episodic-memory plugin in projects with pnpm workspaces or non-standard node_modules layouts.

## Problem

When the plugin's CLI commands (`search`, `show`, `stats`, `sync`) use `npx tsx`, npx resolves tsx from the current working directory's node_modules. In pnpm workspaces, this fails because tsx isn't available at the expected path in the project's node_modules.

Error example:
```
Error: Cannot find module '/home/user/project/node_modules/tsx/dist/cli.mjs'
```

## Solution

Changed all `npx tsx` invocations to run from the plugin's directory using a subshell:
```bash
(cd "$SCRIPT_DIR/.." && npx tsx "./src/search-cli.ts" "$@")
```

This ensures npx uses the plugin's bundled tsx dependency regardless of the user's project structure.

## Testing

- ✅ All tests pass (71/71)
- ✅ Build completes successfully
- ✅ Tested in pnpm workspace environment

## Impact

- No breaking changes
- Backward compatible
- Works for all node_modules layouts (npm, yarn, pnpm, etc.)