### PR TITLE
fix(cli): use plugin node_modules for tsx and add error handling

### DIFF
--- a/cli/episodic-memory
+++ b/cli/episodic-memory
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -o pipefail
 
 # Resolve the real directory even if this script is symlinked
 SOURCE="${BASH_SOURCE[0]}"
@@ -8,6 +10,12 @@ while [ -h "$SOURCE" ]; do
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+# Validate SCRIPT_DIR was resolved successfully
+if [ -z "$SCRIPT_DIR" ]; then
+  echo "Error: Failed to determine script directory" >&2
+  exit 1
+fi
 
 # Main CLI entry point with subcommands
 COMMAND="$1"
@@ -21,22 +29,26 @@ case "$COMMAND" in
 
   search)
     # Route to search implementation
-    npx tsx "$SCRIPT_DIR/../src/search-cli.ts" "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/search-cli.ts" "$@")
+    exit $?
     ;;
 
   show)
     # Route to show implementation
-    npx tsx "$SCRIPT_DIR/../src/show-cli.ts" "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/show-cli.ts" "$@")
+    exit $?
     ;;
 
   stats)
     # Route to stats implementation
-    npx tsx "$SCRIPT_DIR/../src/stats-cli.ts" "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/stats-cli.ts" "$@")
+    exit $?
     ;;
 
   sync)
     # Route to sync implementation
-    npx tsx "$SCRIPT_DIR/../src/sync-cli.ts" "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/sync-cli.ts" "$@")
+    exit $?
     ;;
 
   --help|-h|"")

--- a/cli/index-conversations
+++ b/cli/index-conversations
@@ -1,6 +1,14 @@
 #!/bin/bash
+set -e
+set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Validate SCRIPT_DIR was resolved successfully
+if [ -z "$SCRIPT_DIR" ]; then
+  echo "Error: Failed to determine script directory" >&2
+  exit 1
+fi
 
 case "$1" in
   --help|-h)
@@ -56,27 +64,34 @@ EOF
     exit 0
     ;;
   --session)
-    npx tsx "$SCRIPT_DIR/../src/index-cli.ts" index-session "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/index-cli.ts" index-session "$@")
+    exit $?
     ;;
   --cleanup)
-    npx tsx "$SCRIPT_DIR/../src/index-cli.ts" index-cleanup "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/index-cli.ts" index-cleanup "$@")
+    exit $?
     ;;
   --verify)
-    npx tsx "$SCRIPT_DIR/../src/index-cli.ts" verify "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/index-cli.ts" verify "$@")
+    exit $?
     ;;
   --repair)
-    npx tsx "$SCRIPT_DIR/../src/index-cli.ts" repair "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/index-cli.ts" repair "$@")
+    exit $?
     ;;
   --rebuild)
     echo "⚠️  This will DELETE the entire database and re-index everything."
     read -p "Are you sure? [yes/NO]: " confirm
     if [ "$confirm" = "yes" ]; then
-      npx tsx "$SCRIPT_DIR/../src/index-cli.ts" rebuild "$@"
+      (cd "$SCRIPT_DIR/.." && npx tsx "./src/index-cli.ts" rebuild "$@")
+      exit $?
     else
       echo "Cancelled"
+      exit 0
     fi
     ;;
   *)
-    npx tsx "$SCRIPT_DIR/../src/index-cli.ts" index-all "$@"
+    (cd "$SCRIPT_DIR/.." && npx tsx "./src/index-cli.ts" index-all "$@")
+    exit $?
     ;;
 esac

--- a/cli/mcp-server
+++ b/cli/mcp-server
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+set -o pipefail
+
 # MCP Server entry point for episodic-memory
 # This runs the MCP server using stdio transport
 
@@ -11,5 +14,12 @@ while [ -h "$SOURCE" ]; do
 done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
+# Validate SCRIPT_DIR was resolved successfully
+if [ -z "$SCRIPT_DIR" ]; then
+  echo "Error: Failed to determine script directory" >&2
+  exit 1
+fi
+
 # Run the MCP server
-npx tsx "$SCRIPT_DIR/../src/mcp-server.ts" "$@"
+(cd "$SCRIPT_DIR/.." && npx tsx "./src/mcp-server.ts" "$@")
+exit $?

--- a/cli/search-conversations
+++ b/cli/search-conversations
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+set -o pipefail
+
 cd "$(dirname "$0")"
 
 # Parse arguments
@@ -103,4 +106,12 @@ if [ -z "$QUERY" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-npx tsx "$SCRIPT_DIR/../src/search-cli.ts" "$QUERY" "$MODE" "$LIMIT" "$AFTER" "$BEFORE"
+
+# Validate SCRIPT_DIR was resolved successfully
+if [ -z "$SCRIPT_DIR" ]; then
+  echo "Error: Failed to determine script directory" >&2
+  exit 1
+fi
+
+(cd "$SCRIPT_DIR/.." && npx tsx "./src/search-cli.ts" "$QUERY" "$MODE" "$LIMIT" "$AFTER" "$BEFORE")
+exit $?


### PR DESCRIPTION
## Summary

Fixes SessionStart hook errors when using the episodic-memory plugin in projects with pnpm workspaces or non-standard node_modules layouts.

## Problem

When the plugin's CLI scripts use `npx tsx`, npx resolves tsx from the current working directory's node_modules. In pnpm workspaces, this fails because tsx isn't available at the expected path in the project's node_modules.

Error example:
```
Error: Cannot find module '/home/user/project/node_modules/tsx/dist/cli.mjs'
```

## Solution

Changed all `npx tsx` invocations across all CLI scripts to run from the plugin's directory using subshells:

**Before:**
```bash
npx tsx "$SCRIPT_DIR/../src/file.ts" "$@"
```

**After:**
```bash
(cd "$SCRIPT_DIR/.." && npx tsx "./src/file.ts" "$@")
exit $?
```

This ensures npx uses the plugin's bundled tsx dependency regardless of the user's project structure.

## Additional Improvements

Added proper error handling to all CLI scripts:
- `set -e` and `set -o pipefail` for fail-fast behavior
- Validate `SCRIPT_DIR` is non-empty after resolution
- Explicitly capture and return exit statuses from subshell commands

## Files Modified

- `cli/episodic-memory`
- `cli/index-conversations`
- `cli/search-conversations`
- `cli/mcp-server`

## Testing

- ✅ All 71 tests pass
- ✅ Build completes successfully
- ✅ Tested in pnpm workspace environment
- ✅ Cross-platform compatible (POSIX-compliant bash)

## Impact

- No breaking changes
- Backward compatible with all node package managers (npm, yarn, pnpm)
- Proper error handling and exit codes for automation/CI use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in CLI tools with stricter validation and clearer error messages.
  * Enhanced reliability through better working directory management.
  * Fixed exit status propagation for improved script integration and automation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->