### PR TITLE
refactor: rename session persistence to EPISODIC_MEMORY_SAVE_SDK_LOGS (default: off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ export EPISODIC_MEMORY_API_TOKEN=your-token
 
 # Increase timeout for slow endpoints (milliseconds)
 export EPISODIC_MEMORY_API_TIMEOUT_MS=3000000
+
+# Save SDK session logs for debugging (default: false)
+# When enabled, creates .jsonl files in ~/.claude/projects/<cwd-path>/
+# where <cwd-path> is based on where the CLI/agent runs from
+export EPISODIC_MEMORY_SAVE_SDK_LOGS=true
 ```
 
 These settings only affect episodic-memory's summarization calls, not your interactive Claude sessions.
@@ -153,6 +158,7 @@ These settings only affect episodic-memory's summarization calls, not your inter
 | Component | Uses custom config? |
 |-----------|---------------------|
 | Summarization | Yes (up to 10 calls/sync) |
+| SDK session logs | Yes (SAVE_SDK_LOGS only) |
 | Embeddings | No (local Transformers.js) |
 | Search | No (local SQLite) |
 | MCP tools | No |

--- a/dist/summarizer.js
+++ b/dist/summarizer.js
@@ -10,6 +10,7 @@ import { SUMMARIZER_CONTEXT_MARKER } from './constants.js';
  * - EPISODIC_MEMORY_API_BASE_URL: Custom API endpoint
  * - EPISODIC_MEMORY_API_TOKEN: Auth token for custom endpoint
  * - EPISODIC_MEMORY_API_TIMEOUT_MS: Timeout for API calls (default: SDK default)
+ * - EPISODIC_MEMORY_SAVE_SDK_LOGS: Save SDK session files for debugging (default: false)
  */
 function getApiEnv() {
     const baseUrl = process.env.EPISODIC_MEMORY_API_BASE_URL;
@@ -48,6 +49,7 @@ async function callClaude(prompt, sessionId, useFallback = false) {
         options: {
             model,
             max_tokens: 4096,
+            persistSession: process.env.EPISODIC_MEMORY_SAVE_SDK_LOGS === 'true',
             env: getApiEnv(),
             resume: sessionId,
             // Don't override systemPrompt when resuming - it uses the original session's prompt

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -12,6 +12,7 @@ import { SUMMARIZER_CONTEXT_MARKER } from './constants.js';
  * - EPISODIC_MEMORY_API_BASE_URL: Custom API endpoint
  * - EPISODIC_MEMORY_API_TOKEN: Auth token for custom endpoint
  * - EPISODIC_MEMORY_API_TIMEOUT_MS: Timeout for API calls (default: SDK default)
+ * - EPISODIC_MEMORY_SAVE_SDK_LOGS: Save SDK session files for debugging (default: false)
  */
 function getApiEnv(): Record<string, string | undefined> | undefined {
   const baseUrl = process.env.EPISODIC_MEMORY_API_BASE_URL;
@@ -56,6 +57,7 @@ async function callClaude(prompt: string, sessionId?: string, useFallback = fals
     options: {
       model,
       max_tokens: 4096,
+      persistSession: process.env.EPISODIC_MEMORY_SAVE_SDK_LOGS === 'true',
       env: getApiEnv(),
       resume: sessionId,
       // Don't override systemPrompt when resuming - it uses the original session's prompt


### PR DESCRIPTION
## Summary
Refactor SDK session persistence to be opt-in (default: false) instead of opt-out. Rename env var to better reflect its purpose as a debug feature.

## Problem
When running `sync` or `--rebuild`, the summarizer calls the Claude Agent SDK's `query()` function for each conversation. The SDK creates `.jsonl` session files in `~/.claude/projects/<cwd-path>/` for each call, where `<cwd-path>` is based on where the CLI/agent runs from.

**Impact observed:**
- A rebuild of 1,574 conversations created **23,013 files** (178MB)
- Files include main sessions + SDK agent coordination files
- These files serve no purpose - summaries are already extracted and stored in the archive
- Pollutes user's Claude Code projects directory

## Solution
Add opt-in `EPISODIC_MEMORY_SAVE_SDK_LOGS` environment variable (default: false):

```bash
# Enable SDK session file creation for debugging
export EPISODIC_MEMORY_SAVE_SDK_LOGS=true
```

| Env Var Value | Behavior |
|---------------|----------|
| (unset) | **No session files** (default) |
| `false` | No session files |
| `true` | Creates session files for debugging |

## Changes
- Renamed `EPISODIC_MEMORY_PERSIST_SESSIONS` → `EPISODIC_MEMORY_SAVE_SDK_LOGS`
- Flipped default: now opt-in instead of opt-out
- Added documentation to README.md explaining behavior and file locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EPISODIC_MEMORY_SAVE_SDK_LOGS environment variable to optionally save SDK session logs. Logs are stored in ~/.claude/projects/<cwd-path>/ (default: disabled).

* **Documentation**
  * Updated configuration documentation with the new EPISODIC_MEMORY_SAVE_SDK_LOGS environment variable and its usage details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->