### PR TITLE
fix: add 'clear' to SessionStart matcher

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume",
+        "matcher": "startup|resume|clear",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- Add `clear` to the SessionStart hook matcher so conversations are archived when users run `/clear`

## Details

When users run `/clear` in Claude Code, it fires:
- `SessionEnd` with reason `clear`
- `SessionStart` with source `clear`

The current matcher (`startup|resume`) doesn't catch `clear`, so cleared conversations aren't archived until the next full CLI restart.

This one-line change adds `clear` to the matcher, making `/clear` behave consistently with CLI restart for archiving purposes.

Fixes #50

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended session start event detection to recognize an additional event type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->