### PR TITLE
fix: Add SIGHUP handler and stdin close detection to prevent orphaned processes

### DIFF
--- a/cli/mcp-server-wrapper.js
+++ b/cli/mcp-server-wrapper.js
@@ -84,6 +84,14 @@ async function main() {
     // Forward signals to the child process
     process.on('SIGTERM', () => child.kill('SIGTERM'));
     process.on('SIGINT', () => child.kill('SIGINT'));
+    process.on('SIGHUP', () => child.kill('SIGHUP'));
+
+    // Detect parent process death via stdin close
+    // When Claude exits (normally or abnormally), stdin will close
+    process.stdin.on('end', () => {
+      child.kill();
+      process.exit(0);
+    });
 
     child.on('exit', (code, signal) => {
       if (signal) {


### PR DESCRIPTION
## Summary

- Add SIGHUP signal handler for terminal hangup (closing terminal window)
- Add stdin `end` event listener to detect parent process death

## Problem

MCP server processes become orphaned when Claude sessions end through:
- Closing terminal window (sends SIGHUP, not SIGTERM)
- Claude crashes (no signal sent)
- `kill -9` on Claude process (no signal sent)

Over time, users accumulate dozens of orphaned `mcp-server.js` processes consuming memory.

## Root Cause

The wrapper only handled SIGTERM and SIGINT:

```javascript
process.on('SIGTERM', () => child.kill('SIGTERM'));
process.on('SIGINT', () => child.kill('SIGINT'));
```

## Solution

Add two additional cleanup mechanisms:

```javascript
// Handle terminal hangup
process.on('SIGHUP', () => child.kill('SIGHUP'));

// Detect parent death via stdin close
process.stdin.on('end', () => {
  child.kill();
  process.exit(0);
});
```

The stdin detection is particularly important because it catches *all* abnormal parent exits, including crashes and SIGKILL.

## Test Plan

- [x] Verify normal `/exit` still works (SIGTERM path)
- [ ] Verify closing terminal tab kills child process (SIGHUP path)
- [ ] Verify `kill -9` on Claude kills child process (stdin close path)
- [ ] Verify no orphaned processes after multiple session starts/stops

Fixes #53

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability through enhanced process management and parent process death detection
  * Better signal handling to ensure reliable cleanup of child processes during shutdown

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->