### PR TITLE
feat: add metadata filters (project, session_id, git_branch) to search

### DIFF
--- a/dist/mcp-server.js
+++ b/dist/mcp-server.js
@@ -4725,6 +4725,7 @@ var require_pattern = __commonJS({
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
+    var util_1 = require_util();
     var codegen_1 = require_codegen();
     var error2 = {
       message: ({ schemaCode }) => (0, codegen_1.str)`must match pattern "${schemaCode}"`,
@@ -4737,10 +4738,18 @@ var require_pattern = __commonJS({
       $data: true,
       error: error2,
       code(cxt) {
-        const { data, $data, schema, schemaCode, it } = cxt;
+        const { gen, data, $data, schema, schemaCode, it } = cxt;
         const u = it.opts.unicodeRegExp ? "u" : "";
-        const regExp = $data ? (0, codegen_1._)`(new RegExp(${schemaCode}, ${u}))` : (0, code_1.usePattern)(cxt, schema);
-        cxt.fail$data((0, codegen_1._)`!${regExp}.test(${data})`);
+        if ($data) {
+          const { regExp } = it.opts.code;
+          const regExpCode = regExp.code === "new RegExp" ? (0, codegen_1._)`new RegExp` : (0, util_1.useFunc)(gen, regExp);
+          const valid = gen.let("valid");
+          gen.try(() => gen.assign(valid, (0, codegen_1._)`${regExpCode}(${schemaCode}, ${u}).test(${data})`), () => gen.assign(valid, false));
+          cxt.fail$data((0, codegen_1._)`!${valid}`);
+        } else {
+          const regExp = (0, code_1.usePattern)(cxt, schema);
+          cxt.fail$data((0, codegen_1._)`!${regExp}.test(${data})`);
+        }
       }
     };
     exports.default = def;
@@ -16340,6 +16349,9 @@ var Protocol = class {
    * The Protocol object assumes ownership of the Transport, replacing any callbacks that have already been set, and expects that it is the only user of the Transport instance going forward.
    */
   async connect(transport) {
+    if (this._transport) {
+      throw new Error("Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.");
+    }
     this._transport = transport;
     const _onclose = this.transport?.onclose;
     this._transport.onclose = () => {
@@ -16372,6 +16384,10 @@ var Protocol = class {
     this._progressHandlers.clear();
     this._taskProgressTokens.clear();
     this._pendingDebouncedNotifications.clear();
+    for (const controller of this._requestHandlerAbortControllers.values()) {
+      controller.abort();
+    }
+    this._requestHandlerAbortControllers.clear();
     const error2 = McpError.fromError(ErrorCode.ConnectionClosed, "Connection closed");
     this._transport = void 0;
     this.onclose?.();
@@ -16422,6 +16438,8 @@ var Protocol = class {
       sessionId: capturedTransport?.sessionId,
       _meta: request.params?._meta,
       sendNotification: async (notification) => {
+        if (abortController.signal.aborted)
+          return;
         const notificationOptions = { relatedRequestId: request.id };
         if (relatedTaskId) {
           notificationOptions.relatedTask = { taskId: relatedTaskId };
@@ -16429,6 +16447,9 @@ var Protocol = class {
         await this.notification(notification, notificationOptions);
       },
       sendRequest: async (r, resultSchema, options) => {
+        if (abortController.signal.aborted) {
+          throw new McpError(ErrorCode.ConnectionClosed, "Request was cancelled");
+        }
         const requestOptions = { ...options, relatedRequestId: request.id };
         if (relatedTaskId && !requestOptions.relatedTask) {
           requestOptions.relatedTask = { taskId: relatedTaskId };
@@ -17190,6 +17211,147 @@ var ExperimentalServerTasks = class {
     return this._server.requestStream(request, resultSchema, options);
   }
   /**
+   * Sends a sampling request and returns an AsyncGenerator that yields response messages.
+   * The generator is guaranteed to end with either a 'result' or 'error' message.
+   *
+   * For task-augmented requests, yields 'taskCreated' and 'taskStatus' messages
+   * before the final result.
+   *
+   * @example
+   * ```typescript
+   * const stream = server.experimental.tasks.createMessageStream({
+   *     messages: [{ role: 'user', content: { type: 'text', text: 'Hello' } }],
+   *     maxTokens: 100
+   * }, {
+   *     onprogress: (progress) => {
+   *         // Handle streaming tokens via progress notifications
+   *         console.log('Progress:', progress.message);
+   *     }
+   * });
+   *
+   * for await (const message of stream) {
+   *     switch (message.type) {
+   *         case 'taskCreated':
+   *             console.log('Task created:', message.task.taskId);
+   *             break;
+   *         case 'taskStatus':
+   *             console.log('Task status:', message.task.status);
+   *             break;
+   *         case 'result':
+   *             console.log('Final result:', message.result);
+   *             break;
+   *         case 'error':
+   *             console.error('Error:', message.error);
+   *             break;
+   *     }
+   * }
+   * ```
+   *
+   * @param params - The sampling request parameters
+   * @param options - Optional request options (timeout, signal, task creation params, onprogress, etc.)
+   * @returns AsyncGenerator that yields ResponseMessage objects
+   *
+   * @experimental
+   */
+  createMessageStream(params, options) {
+    const clientCapabilities = this._server.getClientCapabilities();
+    if ((params.tools || params.toolChoice) && !clientCapabilities?.sampling?.tools) {
+      throw new Error("Client does not support sampling tools capability.");
+    }
+    if (params.messages.length > 0) {
+      const lastMessage = params.messages[params.messages.length - 1];
+      const lastContent = Array.isArray(lastMessage.content) ? lastMessage.content : [lastMessage.content];
+      const hasToolResults = lastContent.some((c) => c.type === "tool_result");
+      const previousMessage = params.messages.length > 1 ? params.messages[params.messages.length - 2] : void 0;
+      const previousContent = previousMessage ? Array.isArray(previousMessage.content) ? previousMessage.content : [previousMessage.content] : [];
+      const hasPreviousToolUse = previousContent.some((c) => c.type === "tool_use");
+      if (hasToolResults) {
+        if (lastContent.some((c) => c.type !== "tool_result")) {
+          throw new Error("The last message must contain only tool_result content if any is present");
+        }
+        if (!hasPreviousToolUse) {
+          throw new Error("tool_result blocks are not matching any tool_use from the previous message");
+        }
+      }
+      if (hasPreviousToolUse) {
+        const toolUseIds = new Set(previousContent.filter((c) => c.type === "tool_use").map((c) => c.id));
+        const toolResultIds = new Set(lastContent.filter((c) => c.type === "tool_result").map((c) => c.toolUseId));
+        if (toolUseIds.size !== toolResultIds.size || ![...toolUseIds].every((id) => toolResultIds.has(id))) {
+          throw new Error("ids of tool_result blocks and tool_use blocks from previous message do not match");
+        }
+      }
+    }
+    return this.requestStream({
+      method: "sampling/createMessage",
+      params
+    }, CreateMessageResultSchema, options);
+  }
+  /**
+   * Sends an elicitation request and returns an AsyncGenerator that yields response messages.
+   * The generator is guaranteed to end with either a 'result' or 'error' message.
+   *
+   * For task-augmented requests (especially URL-based elicitation), yields 'taskCreated'
+   * and 'taskStatus' messages before the final result.
+   *
+   * @example
+   * ```typescript
+   * const stream = server.experimental.tasks.elicitInputStream({
+   *     mode: 'url',
+   *     message: 'Please authenticate',
+   *     elicitationId: 'auth-123',
+   *     url: 'https://example.com/auth'
+   * }, {
+   *     task: { ttl: 300000 } // Task-augmented for long-running auth flow
+   * });
+   *
+   * for await (const message of stream) {
+   *     switch (message.type) {
+   *         case 'taskCreated':
+   *             console.log('Task created:', message.task.taskId);
+   *             break;
+   *         case 'taskStatus':
+   *             console.log('Task status:', message.task.status);
+   *             break;
+   *         case 'result':
+   *             console.log('User action:', message.result.action);
+   *             break;
+   *         case 'error':
+   *             console.error('Error:', message.error);
+   *             break;
+   *     }
+   * }
+   * ```
+   *
+   * @param params - The elicitation request parameters
+   * @param options - Optional request options (timeout, signal, task creation params, etc.)
+   * @returns AsyncGenerator that yields ResponseMessage objects
+   *
+   * @experimental
+   */
+  elicitInputStream(params, options) {
+    const clientCapabilities = this._server.getClientCapabilities();
+    const mode = params.mode ?? "form";
+    switch (mode) {
+      case "url": {
+        if (!clientCapabilities?.elicitation?.url) {
+          throw new Error("Client does not support url elicitation.");
+        }
+        break;
+      }
+      case "form": {
+        if (!clientCapabilities?.elicitation?.form) {
+          throw new Error("Client does not support form elicitation.");
+        }
+        break;
+      }
+    }
+    const normalizedParams = mode === "form" && params.mode === void 0 ? { ...params, mode: "form" } : params;
+    return this.requestStream({
+      method: "elicitation/create",
+      params: normalizedParams
+    }, ElicitResultSchema, options);
+  }
+  /**
    * Gets the current status of a task.
    *
    * @param taskId - The task identifier
@@ -17929,16 +18091,33 @@ function validateISODate(dateStr, paramName) {
     throw new Error(`Invalid ${paramName} date: "${dateStr}". Not a valid calendar date.`);
   }
 }
+var SAFE_STRING_REGEX = /^[a-zA-Z0-9._\-\/\s@:~]+$/;
+function validateMetadataFilter(value, paramName) {
+  if (value.length > 500) {
+    throw new Error(`${paramName} filter too long (max 500 characters)`);
+  }
+  if (!SAFE_STRING_REGEX.test(value)) {
+    throw new Error(`Invalid ${paramName} filter: "${value}". Contains unsupported characters.`);
+  }
+}
 async function searchConversations(query, options = {}) {
-  const { limit = 10, mode = "both", after, before } = options;
+  const { limit = 10, mode = "both", after, before, project, session_id, git_branch } = options;
   if (after) validateISODate(after, "--after");
   if (before) validateISODate(before, "--before");
+  if (project) validateMetadataFilter(project, "project");
+  if (session_id) validateMetadataFilter(session_id, "session_id");
+  if (git_branch) validateMetadataFilter(git_branch, "git_branch");
   const db = initDatabase();
   let results = [];
-  const timeFilter = [];
-  if (after) timeFilter.push(`e.timestamp >= '${after}'`);
-  if (before) timeFilter.push(`e.timestamp <= '${before}'`);
-  const timeClause = timeFilter.length > 0 ? `AND ${timeFilter.join(" AND ")}` : "";
+  const filters = [];
+  if (after) filters.push(`e.timestamp >= '${after}'`);
+  if (before) filters.push(`e.timestamp <= '${before}'`);
+  if (project) filters.push(`e.project = '${project}'`);
+  if (session_id) filters.push(`e.session_id = '${session_id}'`);
+  if (git_branch) filters.push(`e.git_branch = '${git_branch}'`);
+  const filterClause = filters.length > 0 ? `AND ${filters.join(" AND ")}` : "";
+  const hasMetadataFilter = project || session_id || git_branch;
+  const effectiveK = hasMetadataFilter ? limit * 3 : limit;
   if (mode === "vector" || mode === "both") {
     await initEmbeddings();
     const queryEmbedding = await generateEmbedding(query);
@@ -17952,18 +18131,23 @@ async function searchConversations(query, options = {}) {
         e.archive_path,
         e.line_start,
         e.line_end,
+        e.session_id,
+        e.git_branch,
         vec.distance
       FROM vec_exchanges AS vec
       JOIN exchanges AS e ON vec.id = e.id
       WHERE vec.embedding MATCH ?
         AND k = ?
-        ${timeClause}
+        ${filterClause}
       ORDER BY vec.distance ASC
     `);
     results = stmt.all(
       Buffer.from(new Float32Array(queryEmbedding).buffer),
-      limit
+      effectiveK
     );
+    if (hasMetadataFilter && results.length > limit) {
+      results = results.slice(0, limit);
+    }
   }
   if (mode === "text" || mode === "both") {
     const textStmt = db.prepare(`
@@ -17976,10 +18160,12 @@ async function searchConversations(query, options = {}) {
         e.archive_path,
         e.line_start,
         e.line_end,
+        e.session_id,
+        e.git_branch,
         0 as distance
       FROM exchanges AS e
       WHERE (e.user_message LIKE ? OR e.assistant_message LIKE ?)
-        ${timeClause}
+        ${filterClause}
       ORDER BY e.timestamp DESC
       LIMIT ?
     `);
@@ -18005,7 +18191,9 @@ async function searchConversations(query, options = {}) {
       assistantMessage: row.assistant_message,
       archivePath: row.archive_path,
       lineStart: row.line_start,
-      lineEnd: row.line_end
+      lineEnd: row.line_end,
+      sessionId: row.session_id || void 0,
+      gitBranch: row.git_branch || void 0
     };
     const summaryPath = row.archive_path.replace(".jsonl", "-summary.txt");
     let summary;
@@ -19539,6 +19727,9 @@ var SearchInputSchema = external_exports.object({
   limit: external_exports.number().int().min(1).max(50).default(10).describe("Maximum number of results to return (default: 10)"),
   after: external_exports.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format").optional().describe("Only return conversations after this date (YYYY-MM-DD format)"),
   before: external_exports.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format").optional().describe("Only return conversations before this date (YYYY-MM-DD format)"),
+  project: external_exports.string().min(1).optional().describe("Filter by project name (exact match)"),
+  session_id: external_exports.string().min(1).optional().describe("Filter by session ID (exact match)"),
+  git_branch: external_exports.string().min(1).optional().describe("Filter by git branch (exact match)"),
   response_format: ResponseFormatEnum.default("markdown").describe(
     'Output format: "markdown" for human-readable or "json" for machine-readable (default: "markdown")'
   )
@@ -19584,6 +19775,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             limit: { type: "number", minimum: 1, maximum: 50, default: 10 },
             after: { type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$" },
             before: { type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$" },
+            project: { type: "string", minLength: 1, description: "Filter by project name" },
+            session_id: { type: "string", minLength: 1, description: "Filter by session ID" },
+            git_branch: { type: "string", minLength: 1, description: "Filter by git branch" },
             response_format: { type: "string", enum: ["markdown", "json"], default: "markdown" }
           },
           required: ["query"],
@@ -19631,7 +19825,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const options = {
           limit: params.limit,
           after: params.after,
-          before: params.before
+          before: params.before,
+          project: params.project,
+          session_id: params.session_id,
+          git_branch: params.git_branch
         };
         const results = await searchMultipleConcepts(params.query, options);
         if (params.response_format === "json") {
@@ -19652,7 +19849,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           mode: params.mode,
           limit: params.limit,
           after: params.after,
-          before: params.before
+          before: params.before,
+          project: params.project,
+          session_id: params.session_id,
+          git_branch: params.git_branch
         };
         const results = await searchConversations(params.query, options);
         if (params.response_format === "json") {

--- a/dist/search-cli.js
+++ b/dist/search-cli.js
@@ -4,6 +4,9 @@ const args = process.argv.slice(2);
 let mode = 'both';
 let after;
 let before;
+let project;
+let sessionId;
+let gitBranch;
 let limit = 10;
 const queries = [];
 for (let i = 0; i < args.length; i++) {
@@ -20,10 +23,13 @@ MODES:
   --text         Exact string matching only (for git SHAs, error codes)
 
 OPTIONS:
-  --after DATE   Only conversations after YYYY-MM-DD
-  --before DATE  Only conversations before YYYY-MM-DD
-  --limit N      Max results (default: 10)
-  --help, -h     Show this help
+  --after DATE        Only conversations after YYYY-MM-DD
+  --before DATE       Only conversations before YYYY-MM-DD
+  --project NAME      Filter by project name (exact match)
+  --session-id ID     Filter by session ID (exact match)
+  --git-branch BRANCH Filter by git branch (exact match)
+  --limit N           Max results (default: 10)
+  --help, -h          Show this help
 
 EXAMPLES:
   # Semantic search
@@ -34,6 +40,12 @@ EXAMPLES:
 
   # Time filtering
   episodic-memory search --after 2025-09-01 "refactoring"
+
+  # Filter by project
+  episodic-memory search --project my-app "authentication"
+
+  # Filter by git branch
+  episodic-memory search --git-branch feat/login "auth flow"
 
   # Combine modes
   episodic-memory search --both "React Router data loading"
@@ -55,6 +67,15 @@ EXAMPLES:
     else if (arg === '--before') {
         before = args[++i];
     }
+    else if (arg === '--project') {
+        project = args[++i];
+    }
+    else if (arg === '--session-id') {
+        sessionId = args[++i];
+    }
+    else if (arg === '--git-branch') {
+        gitBranch = args[++i];
+    }
     else if (arg === '--limit') {
         limit = parseInt(args[++i]);
     }
@@ -70,7 +91,7 @@ if (queries.length === 0) {
 }
 // Multi-concept search if multiple queries provided
 if (queries.length > 1) {
-    const options = { limit, after, before };
+    const options = { limit, after, before, project, session_id: sessionId, git_branch: gitBranch };
     searchMultipleConcepts(queries, options)
         .then(async (results) => {
         console.log(await formatMultiConceptResults(results, queries));
@@ -86,7 +107,10 @@ else {
         mode,
         limit,
         after,
-        before
+        before,
+        project,
+        session_id: sessionId,
+        git_branch: gitBranch,
     };
     searchConversations(queries[0], options)
         .then(async (results) => {

--- a/dist/search.d.ts
+++ b/dist/search.d.ts
@@ -4,6 +4,9 @@ export interface SearchOptions {
     mode?: 'vector' | 'text' | 'both';
     after?: string;
     before?: string;
+    project?: string;
+    session_id?: string;
+    git_branch?: string;
 }
 export declare function searchConversations(query: string, options?: SearchOptions): Promise<SearchResult[]>;
 export declare function formatResults(results: Array<SearchResult & {

--- a/dist/search.js
+++ b/dist/search.js
@@ -13,22 +13,46 @@ function validateISODate(dateStr, paramName) {
         throw new Error(`Invalid ${paramName} date: "${dateStr}". Not a valid calendar date.`);
     }
 }
+const SAFE_STRING_REGEX = /^[a-zA-Z0-9._\-\/\s@:~]+$/;
+function validateMetadataFilter(value, paramName) {
+    if (value.length > 500) {
+        throw new Error(`${paramName} filter too long (max 500 characters)`);
+    }
+    if (!SAFE_STRING_REGEX.test(value)) {
+        throw new Error(`Invalid ${paramName} filter: "${value}". Contains unsupported characters.`);
+    }
+}
 export async function searchConversations(query, options = {}) {
-    const { limit = 10, mode = 'both', after, before } = options;
-    // Validate date parameters
+    const { limit = 10, mode = 'both', after, before, project, session_id, git_branch } = options;
+    // Validate parameters
     if (after)
         validateISODate(after, '--after');
     if (before)
         validateISODate(before, '--before');
+    if (project)
+        validateMetadataFilter(project, 'project');
+    if (session_id)
+        validateMetadataFilter(session_id, 'session_id');
+    if (git_branch)
+        validateMetadataFilter(git_branch, 'git_branch');
     const db = initDatabase();
     let results = [];
-    // Build time filter clause
-    const timeFilter = [];
+    // Build filter clause (time + metadata)
+    const filters = [];
     if (after)
-        timeFilter.push(`e.timestamp >= '${after}'`);
+        filters.push(`e.timestamp >= '${after}'`);
     if (before)
-        timeFilter.push(`e.timestamp <= '${before}'`);
-    const timeClause = timeFilter.length > 0 ? `AND ${timeFilter.join(' AND ')}` : '';
+        filters.push(`e.timestamp <= '${before}'`);
+    if (project)
+        filters.push(`e.project = '${project}'`);
+    if (session_id)
+        filters.push(`e.session_id = '${session_id}'`);
+    if (git_branch)
+        filters.push(`e.git_branch = '${git_branch}'`);
+    const filterClause = filters.length > 0 ? `AND ${filters.join(' AND ')}` : '';
+    // vec0 applies KNN before WHERE post-filter, so over-fetch when metadata filters are active
+    const hasMetadataFilter = project || session_id || git_branch;
+    const effectiveK = hasMetadataFilter ? limit * 3 : limit;
     if (mode === 'vector' || mode === 'both') {
         // Vector similarity search
         await initEmbeddings();
@@ -43,15 +67,21 @@ export async function searchConversations(query, options = {}) {
         e.archive_path,
         e.line_start,
         e.line_end,
+        e.session_id,
+        e.git_branch,
         vec.distance
       FROM vec_exchanges AS vec
       JOIN exchanges AS e ON vec.id = e.id
       WHERE vec.embedding MATCH ?
         AND k = ?
-        ${timeClause}
+        ${filterClause}
       ORDER BY vec.distance ASC
     `);
-        results = stmt.all(Buffer.from(new Float32Array(queryEmbedding).buffer), limit);
+        results = stmt.all(Buffer.from(new Float32Array(queryEmbedding).buffer), effectiveK);
+        // Trim to requested limit after post-filtering
+        if (hasMetadataFilter && results.length > limit) {
+            results = results.slice(0, limit);
+        }
     }
     if (mode === 'text' || mode === 'both') {
         // Text search
@@ -65,10 +95,12 @@ export async function searchConversations(query, options = {}) {
         e.archive_path,
         e.line_start,
         e.line_end,
+        e.session_id,
+        e.git_branch,
         0 as distance
       FROM exchanges AS e
       WHERE (e.user_message LIKE ? OR e.assistant_message LIKE ?)
-        ${timeClause}
+        ${filterClause}
       ORDER BY e.timestamp DESC
       LIMIT ?
     `);
@@ -96,7 +128,9 @@ export async function searchConversations(query, options = {}) {
             assistantMessage: row.assistant_message,
             archivePath: row.archive_path,
             lineStart: row.line_start,
-            lineEnd: row.line_end
+            lineEnd: row.line_end,
+            sessionId: row.session_id || undefined,
+            gitBranch: row.git_branch || undefined,
         };
         // Try to load summary if available
         const summaryPath = row.archive_path.replace('.jsonl', '-summary.txt');

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -61,6 +61,21 @@ const SearchInputSchema = z
       .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
       .optional()
       .describe('Only return conversations before this date (YYYY-MM-DD format)'),
+    project: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Filter by project name (exact match)'),
+    session_id: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Filter by session ID (exact match)'),
+    git_branch: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Filter by git branch (exact match)'),
     response_format: ResponseFormatEnum.default('markdown').describe(
       'Output format: "markdown" for human-readable or "json" for machine-readable (default: "markdown")'
     ),
@@ -136,6 +151,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             limit: { type: 'number', minimum: 1, maximum: 50, default: 10 },
             after: { type: 'string', pattern: '^\\d{4}-\\d{2}-\\d{2}$' },
             before: { type: 'string', pattern: '^\\d{4}-\\d{2}-\\d{2}$' },
+            project: { type: 'string', minLength: 1, description: 'Filter by project name' },
+            session_id: { type: 'string', minLength: 1, description: 'Filter by session ID' },
+            git_branch: { type: 'string', minLength: 1, description: 'Filter by git branch' },
             response_format: { type: 'string', enum: ['markdown', 'json'], default: 'markdown' },
           },
           required: ['query'],
@@ -191,6 +209,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           limit: params.limit,
           after: params.after,
           before: params.before,
+          project: params.project,
+          session_id: params.session_id,
+          git_branch: params.git_branch,
         };
 
         const results = await searchMultipleConcepts(params.query, options);
@@ -215,6 +236,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           limit: params.limit,
           after: params.after,
           before: params.before,
+          project: params.project,
+          session_id: params.session_id,
+          git_branch: params.git_branch,
         };
 
         const results = await searchConversations(params.query, options);

--- a/src/search-cli.ts
+++ b/src/search-cli.ts
@@ -6,6 +6,9 @@ const args = process.argv.slice(2);
 let mode: 'vector' | 'text' | 'both' = 'both';
 let after: string | undefined;
 let before: string | undefined;
+let project: string | undefined;
+let sessionId: string | undefined;
+let gitBranch: string | undefined;
 let limit = 10;
 const queries: string[] = [];
 
@@ -24,10 +27,13 @@ MODES:
   --text         Exact string matching only (for git SHAs, error codes)
 
 OPTIONS:
-  --after DATE   Only conversations after YYYY-MM-DD
-  --before DATE  Only conversations before YYYY-MM-DD
-  --limit N      Max results (default: 10)
-  --help, -h     Show this help
+  --after DATE        Only conversations after YYYY-MM-DD
+  --before DATE       Only conversations before YYYY-MM-DD
+  --project NAME      Filter by project name (exact match)
+  --session-id ID     Filter by session ID (exact match)
+  --git-branch BRANCH Filter by git branch (exact match)
+  --limit N           Max results (default: 10)
+  --help, -h          Show this help
 
 EXAMPLES:
   # Semantic search
@@ -38,6 +44,12 @@ EXAMPLES:
 
   # Time filtering
   episodic-memory search --after 2025-09-01 "refactoring"
+
+  # Filter by project
+  episodic-memory search --project my-app "authentication"
+
+  # Filter by git branch
+  episodic-memory search --git-branch feat/login "auth flow"
 
   # Combine modes
   episodic-memory search --both "React Router data loading"
@@ -54,6 +66,12 @@ EXAMPLES:
     after = args[++i];
   } else if (arg === '--before') {
     before = args[++i];
+  } else if (arg === '--project') {
+    project = args[++i];
+  } else if (arg === '--session-id') {
+    sessionId = args[++i];
+  } else if (arg === '--git-branch') {
+    gitBranch = args[++i];
   } else if (arg === '--limit') {
     limit = parseInt(args[++i]);
   } else {
@@ -70,7 +88,7 @@ if (queries.length === 0) {
 
 // Multi-concept search if multiple queries provided
 if (queries.length > 1) {
-  const options = { limit, after, before };
+  const options = { limit, after, before, project, session_id: sessionId, git_branch: gitBranch };
 
   searchMultipleConcepts(queries, options)
     .then(async results => {
@@ -86,7 +104,10 @@ if (queries.length > 1) {
     mode,
     limit,
     after,
-    before
+    before,
+    project,
+    session_id: sessionId,
+    git_branch: gitBranch,
   };
 
   searchConversations(queries[0], options)

--- a/src/search.ts
+++ b/src/search.ts
@@ -10,6 +10,9 @@ export interface SearchOptions {
   mode?: 'vector' | 'text' | 'both';
   after?: string;  // ISO date string
   before?: string; // ISO date string
+  project?: string;
+  session_id?: string;
+  git_branch?: string;
 }
 
 function validateISODate(dateStr: string, paramName: string): void {
@@ -24,25 +27,46 @@ function validateISODate(dateStr: string, paramName: string): void {
   }
 }
 
+const SAFE_STRING_REGEX = /^[a-zA-Z0-9._\-\/\s@:~]+$/;
+
+function validateMetadataFilter(value: string, paramName: string): void {
+  if (value.length > 500) {
+    throw new Error(`${paramName} filter too long (max 500 characters)`);
+  }
+  if (!SAFE_STRING_REGEX.test(value)) {
+    throw new Error(`Invalid ${paramName} filter: "${value}". Contains unsupported characters.`);
+  }
+}
+
 export async function searchConversations(
   query: string,
   options: SearchOptions = {}
 ): Promise<SearchResult[]> {
-  const { limit = 10, mode = 'both', after, before } = options;
+  const { limit = 10, mode = 'both', after, before, project, session_id, git_branch } = options;
 
-  // Validate date parameters
+  // Validate parameters
   if (after) validateISODate(after, '--after');
   if (before) validateISODate(before, '--before');
+  if (project) validateMetadataFilter(project, 'project');
+  if (session_id) validateMetadataFilter(session_id, 'session_id');
+  if (git_branch) validateMetadataFilter(git_branch, 'git_branch');
 
   const db = initDatabase();
 
   let results: any[] = [];
 
-  // Build time filter clause
-  const timeFilter = [];
-  if (after) timeFilter.push(`e.timestamp >= '${after}'`);
-  if (before) timeFilter.push(`e.timestamp <= '${before}'`);
-  const timeClause = timeFilter.length > 0 ? `AND ${timeFilter.join(' AND ')}` : '';
+  // Build filter clause (time + metadata)
+  const filters: string[] = [];
+  if (after) filters.push(`e.timestamp >= '${after}'`);
+  if (before) filters.push(`e.timestamp <= '${before}'`);
+  if (project) filters.push(`e.project = '${project}'`);
+  if (session_id) filters.push(`e.session_id = '${session_id}'`);
+  if (git_branch) filters.push(`e.git_branch = '${git_branch}'`);
+  const filterClause = filters.length > 0 ? `AND ${filters.join(' AND ')}` : '';
+
+  // vec0 applies KNN before WHERE post-filter, so over-fetch when metadata filters are active
+  const hasMetadataFilter = project || session_id || git_branch;
+  const effectiveK = hasMetadataFilter ? limit * 3 : limit;
 
   if (mode === 'vector' || mode === 'both') {
     // Vector similarity search
@@ -59,19 +83,26 @@ export async function searchConversations(
         e.archive_path,
         e.line_start,
         e.line_end,
+        e.session_id,
+        e.git_branch,
         vec.distance
       FROM vec_exchanges AS vec
       JOIN exchanges AS e ON vec.id = e.id
       WHERE vec.embedding MATCH ?
         AND k = ?
-        ${timeClause}
+        ${filterClause}
       ORDER BY vec.distance ASC
     `);
 
     results = stmt.all(
       Buffer.from(new Float32Array(queryEmbedding).buffer),
-      limit
+      effectiveK
     );
+
+    // Trim to requested limit after post-filtering
+    if (hasMetadataFilter && results.length > limit) {
+      results = results.slice(0, limit);
+    }
   }
 
   if (mode === 'text' || mode === 'both') {
@@ -86,10 +117,12 @@ export async function searchConversations(
         e.archive_path,
         e.line_start,
         e.line_end,
+        e.session_id,
+        e.git_branch,
         0 as distance
       FROM exchanges AS e
       WHERE (e.user_message LIKE ? OR e.assistant_message LIKE ?)
-        ${timeClause}
+        ${filterClause}
       ORDER BY e.timestamp DESC
       LIMIT ?
     `);
@@ -120,7 +153,9 @@ export async function searchConversations(
       assistantMessage: row.assistant_message,
       archivePath: row.archive_path,
       lineStart: row.line_start,
-      lineEnd: row.line_end
+      lineEnd: row.line_end,
+      sessionId: row.session_id || undefined,
+      gitBranch: row.git_branch || undefined,
     };
 
     // Try to load summary if available

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { initDatabase } from '../src/db.js';
-import { searchConversations } from '../src/search.js';
+import { searchConversations, SearchOptions } from '../src/search.js';
 import { parseConversationFile } from '../src/parser.js';
 import { createTestDb, getFixturePath } from './test-utils.js';
 import { indexTestFiles } from './test-indexer.js';
@@ -245,6 +245,127 @@ describe('Integration Tests', () => {
         expect(date >= new Date('2025-10-01')).toBe(true);
         expect(date <= new Date('2025-10-31')).toBe(true);
       });
+    });
+  });
+
+  describe('Metadata Filtering', () => {
+    beforeEach(async () => {
+      // Index test conversations
+      await indexTestFiles([getFixturePath('short-conversation.jsonl')]);
+
+      // Set metadata on indexed exchanges for filtering tests
+      const db = initDatabase();
+
+      // Get all exchange IDs
+      const rows = db.prepare('SELECT id FROM exchanges').all() as Array<{ id: string }>;
+      expect(rows.length).toBeGreaterThan(0);
+
+      // Set metadata on the first exchange
+      db.prepare(`
+        UPDATE exchanges SET project = ?, session_id = ?, git_branch = ? WHERE id = ?
+      `).run('test-project-alpha', 'session-abc-123', 'feat/login', rows[0].id);
+
+      // Set different metadata on remaining exchanges (if any)
+      for (let i = 1; i < rows.length; i++) {
+        db.prepare(`
+          UPDATE exchanges SET project = ?, session_id = ?, git_branch = ? WHERE id = ?
+        `).run('test-project-beta', 'session-def-456', 'main', rows[i].id);
+      }
+
+      db.close();
+    });
+
+    it('should filter by project', async () => {
+      const results = await searchConversations('class', {
+        mode: 'text',
+        project: 'test-project-alpha',
+      });
+
+      results.forEach(r => {
+        expect(r.exchange.project).toBe('test-project-alpha');
+      });
+    });
+
+    it('should return empty results for non-matching project', async () => {
+      const results = await searchConversations('class', {
+        mode: 'text',
+        project: 'nonexistent-project',
+      });
+
+      expect(results.length).toBe(0);
+    });
+
+    it('should filter by git_branch', async () => {
+      const results = await searchConversations('class', {
+        mode: 'text',
+        git_branch: 'main',
+      });
+
+      results.forEach(r => {
+        expect(r.exchange.gitBranch).toBe('main');
+      });
+    });
+
+    it('should filter by session_id', async () => {
+      const results = await searchConversations('class', {
+        mode: 'text',
+        session_id: 'session-abc-123',
+      });
+
+      results.forEach(r => {
+        expect(r.exchange.sessionId).toBe('session-abc-123');
+      });
+    });
+
+    it('should combine metadata and time filters', async () => {
+      const results = await searchConversations('class', {
+        mode: 'text',
+        project: 'test-project-alpha',
+        after: '2025-01-01',
+      });
+
+      results.forEach(r => {
+        expect(r.exchange.project).toBe('test-project-alpha');
+        const date = new Date(r.exchange.timestamp);
+        expect(date >= new Date('2025-01-01')).toBe(true);
+      });
+    });
+
+    it('should reject invalid metadata filter characters', async () => {
+      await expect(
+        searchConversations('test', { project: "'; DROP TABLE exchanges; --" })
+      ).rejects.toThrow('Contains unsupported characters');
+    });
+
+    it('should reject overly long metadata filter', async () => {
+      const longString = 'a'.repeat(501);
+      await expect(
+        searchConversations('test', { project: longString })
+      ).rejects.toThrow('filter too long');
+    });
+
+    it('should work with vector search mode', async () => {
+      const results = await searchConversations('class design', {
+        mode: 'vector',
+        project: 'test-project-alpha',
+      });
+
+      results.forEach(r => {
+        expect(r.exchange.project).toBe('test-project-alpha');
+      });
+    });
+
+    it('should return all results when no metadata filter is applied', async () => {
+      const filteredResults = await searchConversations('class', {
+        mode: 'text',
+        project: 'test-project-alpha',
+      });
+      const allResults = await searchConversations('class', {
+        mode: 'text',
+      });
+
+      // Without filter should return >= filtered count
+      expect(allResults.length).toBeGreaterThanOrEqual(filteredResults.length);
     });
   });
 });


### PR DESCRIPTION
## Summary

The `exchanges` table already has indexed columns for `project`, `session_id`, and `git_branch`, but the search API only exposes time-based filters (`after`/`before`). This PR adds metadata filtering to both the MCP tool and the CLI, enabling project-specific and branch-specific conversation searches.

**Motivation:** Multi-project users frequently need to scope search results to a specific project or git branch. The data and indexes already exist in the database — this change simply exposes them through the existing search interfaces.

## Changes

### `src/search.ts`
- Extended `SearchOptions` interface with `project`, `session_id`, `git_branch`
- Added `validateMetadataFilter()` — regex validation + length check, matching the existing `validateISODate()` pattern
- Unified `timeFilter` array → general `filters` array for WHERE clause construction
- Added 3x over-fetch for vector search when metadata filters are active (vec0 virtual table applies KNN before WHERE post-filter)
- Added `session_id`, `git_branch` to SELECT columns and result mapping

### `src/mcp-server.ts`
- Added Zod schema entries for new parameters (with `min(1)` + `.optional()`)
- Added JSON schema entries in `ListToolsRequestSchema` handler
- Passed new parameters through in both single and multi-concept search paths

### `src/search-cli.ts`
- Added `--project`, `--session-id`, `--git-branch` CLI flags
- Updated help text with new options and examples

### `test/integration.test.ts`
- Added `describe('Metadata Filtering')` block with 9 tests:
  - Filter by project / non-matching project returns empty / filter by git_branch / filter by session_id
  - Combined metadata + time filters
  - SQL injection rejection / overly long input rejection
  - Vector search mode with metadata filter
  - Backward compatibility (no filter = same results)

## Design decisions

- **Input validation:** Follows the existing pattern of regex validation + string interpolation (same as `validateISODate`). A full parameterized query refactor is out of scope for this PR.
- **Over-fetch factor (3x):** Conservative multiplier to compensate for vec0's KNN-first behavior when metadata filters reduce the result set. The results are trimmed back to the requested limit after filtering.
- **Exact match only:** All three filters use `=` (exact match). Prefix/fuzzy matching can be added in a follow-up if needed.

## Backward compatibility

All new parameters are optional. When omitted, behavior is identical to the current version — the `filters` array remains empty and produces the same SQL as the previous `timeFilter` approach.

## Test plan

- [x] `npm run build` — compiles without errors
- [x] `npm test` — all new tests pass; no regressions in existing tests
- [x] Existing tests with no filters behave identically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added metadata filtering to search: users can now filter results by project name, session ID, and git branch.
  * Search results now include session ID and git branch information for better context and traceability.
  * CLI now supports --project, --session-id, and --git-branch filter options for refined queries.
  * Input validation ensures filter values meet safety requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->