### PR TITLE
feat: improve remembering-conversations skill (70% → 100%)

### DIFF
--- a/skills/remembering-conversations/SKILL.md
+++ b/skills/remembering-conversations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remembering-conversations
-description: Use when user asks 'how should I...' or 'what's the best approach...' after exploring code, OR when you've tried to solve something and are stuck, OR for unfamiliar workflows, OR when user references past work. Searches conversation history.
+description: Retrieves and synthesizes relevant context from past conversations to surface prior decisions, patterns, and gotchas — returning actionable insights without consuming large amounts of context. Use when user asks 'how should I approach this codebase decision...' or 'what's the best architecture/pattern for...', when stuck on a complex problem with no obvious solution in current code, when following an unfamiliar workflow, or when user references past work with phrases like 'last time', 'we discussed', 'you implemented', or 'do you remember'.
 ---
 
 # Remembering Conversations
@@ -22,26 +22,20 @@ Task tool:
   subagent_type: "search-conversations"
 ```
 
-The agent will:
-1. Search with the `search` tool
-2. Read top 2-5 results with the `show` tool
-3. Synthesize findings (200-1000 words)
-4. Return actionable insights + sources
-
-**Saves 50-100x context vs. loading raw conversations.**
+The agent searches with the `search` tool, reads top 2-5 results with the `show` tool, and returns a 200–1000 word synthesis of actionable insights and sources — **saving 50–100× context vs. loading raw conversations.**
 
 ## When to Use
 
-You often get value out of consulting your episodic memory once you understand what you're being asked. Search memory in these situations:
+Search memory once you understand what you're being asked:
 
 **After understanding the task:**
-- User asks "how should I..." or "what's the best approach..."
-- You've explored current codebase and need to make architectural decisions
-- User asks for implementation approach after describing what they want
+- User asks "how should I..." or "what's the best approach..." for an architectural or implementation decision
+- You've explored the current codebase and need to make design choices
+- User asks for an implementation approach after describing what they want
 
 **When you're stuck:**
 - You've investigated a problem and can't find the solution
-- Facing a complex problem without obvious solution in current code
+- Facing a complex problem without an obvious solution in current code
 - Need to follow an unfamiliar workflow or process
 
 **When historical signals are present:**
@@ -51,15 +45,17 @@ You often get value out of consulting your episodic memory once you understand w
 
 **Don't search first:**
 - For current codebase structure (use Grep/Read to explore first)
-- For info in current conversation
+- For info already in the current conversation
 - Before understanding what you're being asked to do
+
+## Handling Insufficient Results
+
+If the search returns nothing useful or too little context:
+- **Try broader terms:** swap specific identifiers for general concepts (e.g., "authentication" instead of "JWT refresh token handler")
+- **Try alternative phrasings:** rephrase the query around the problem domain rather than the solution
+- **Try a second search:** dispatch the agent again with the refined query before giving up
+- **If still empty:** inform the user that no prior context exists on this topic and proceed without it
 
 ## Direct Tool Access (Discouraged)
 
-You CAN use MCP tools directly, but DON'T:
-- `mcp__plugin_episodic-memory_episodic-memory__search`
-- `mcp__plugin_episodic-memory_episodic-memory__show`
-
-Using these directly wastes your context window. Always dispatch the agent instead.
-
-See MCP-TOOLS.md for complete API reference if needed for advanced usage.
+You CAN use MCP tools directly — `mcp__plugin_episodic-memory_episodic-memory__search` and `mcp__plugin_episodic-memory_episodic-memory__show` — but doing so wastes your context window. Always dispatch the agent instead. See MCP-TOOLS.md for the complete API reference.


### PR DESCRIPTION
@obra Hullo 👋

I ran your skill through `tessl skill review` at work and found some targeted improvements. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| remembering-conversations | 70% | 100% | +30% |

<details>
<summary>Changes made</summary>

- **Expanded frontmatter description** — added concrete actions (retrieves, synthesizes, surfaces prior decisions/patterns/gotchas) and clarified trigger phrases with more specific context (e.g., "codebase decision" vs generic "how should I")
- **Condensed agent behaviour explanation** — collapsed the numbered step list into a single sentence to reduce token overhead while preserving the same information
- **Tightened "When to Use" section** — removed introductory padding and sharpened bullet points for quicker parsing
- **Added "Handling Insufficient Results" section** — new actionable feedback loop with three recovery strategies (broader terms, alternative phrasings, second search) plus a clear fallback when no prior context exists
- **Consolidated "Direct Tool Access" section** — compressed from multi-line list into a single compact paragraph

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

If you want to run reviews, evals and optimizations yourself, just `npm install @tessl/cli` then run `tessl skill review path/to/your/SKILL.md`, and click [here](https://tessl.io/registry/skills/submit) to find out more.

Thanks in advance 🙏

## Summary

Improved the `remembering-conversations` SKILL.md — expanded the frontmatter description with concrete actions and specific trigger phrases, condensed verbose explanations, and added a new "Handling Insufficient Results" section with recovery strategies. Overall skill review score went from 70% to 100%.

## Motivation and Context

The skill's frontmatter description was vague ("Searches conversation history") and lacked concrete actions, making it harder for agents to understand when and how to use it. Some content sections were more verbose than needed, and there was no guidance for what to do when a search returns insufficient results.

## How Has This Been Tested?

Reviewed with `tessl skill review` before and after changes. The skill scored 70% before (Description: 55%, Content: 85%) and 100% after (Description: 100%, Content: 100%).

## Breaking Changes

None. All changes are to the SKILL.md prompt content only — no code, configuration, or API changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Evaluated using `tessl skill review` which scores skills on description quality (specificity, trigger terms, completeness, distinctiveness) and content quality (conciseness, actionability, workflow clarity, progressive disclosure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced remembering-conversations skill documentation with clearer descriptions and practical usage examples
  * Improved guidance for handling insufficient search results with alternative strategies and fallback options
  * Updated best practices for tool access and context optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->