### PR TITLE
docs: Fix npm install to use GitHub source

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The plugin automatically:
 ### As an npm package
 
 ```bash
-npm install -g episodic-memory
+npm install -g github:obra/episodic-memory
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- The package is not published to npm, so `npm install episodic-memory` fails with a 404
- Changed to `npm install -g github:obra/episodic-memory` which installs from this repo and puts the CLI binaries on the user's PATH

## Test plan

- [ ] Verify `npm install -g github:obra/episodic-memory` installs successfully and `episodic-memory` is on PATH