### PR TITLE
fix: convert sqlite-vec distances into cosine similarity scores

### DIFF
--- a/dist/search.d.ts
+++ b/dist/search.d.ts
@@ -5,6 +5,7 @@ export interface SearchOptions {
     after?: string;
     before?: string;
 }
+export declare function normalizedL2DistanceToSimilarity(distance: number): number;
 export declare function searchConversations(query: string, options?: SearchOptions): Promise<SearchResult[]>;
 export declare function formatResults(results: Array<SearchResult & {
     summary?: string;

--- a/dist/search.js
+++ b/dist/search.js
@@ -2,6 +2,10 @@ import { initDatabase } from './db.js';
 import { initEmbeddings, generateEmbedding } from './embeddings.js';
 import fs from 'fs';
 import readline from 'readline';
+export function normalizedL2DistanceToSimilarity(distance) {
+    const similarity = 1 - ((distance * distance) / 2);
+    return Math.max(-1, Math.min(1, similarity));
+}
 function validateISODate(dateStr, paramName) {
     const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
     if (!isoDateRegex.test(dateStr)) {
@@ -111,7 +115,7 @@ export async function searchConversations(query, options = {}) {
         const snippet = snippetText + (exchange.userMessage.length > 200 ? '...' : '');
         return {
             exchange,
-            similarity: mode === 'text' ? undefined : 1 - row.distance,
+            similarity: mode === 'text' ? undefined : normalizedL2DistanceToSimilarity(row.distance),
             snippet,
             summary
         };

--- a/src/search.ts
+++ b/src/search.ts
@@ -12,6 +12,11 @@ export interface SearchOptions {
   before?: string; // ISO date string
 }
 
+export function normalizedL2DistanceToSimilarity(distance: number): number {
+  const similarity = 1 - ((distance * distance) / 2);
+  return Math.max(-1, Math.min(1, similarity));
+}
+
 function validateISODate(dateStr: string, paramName: string): void {
   const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
   if (!isoDateRegex.test(dateStr)) {
@@ -138,7 +143,7 @@ export async function searchConversations(
 
     return {
       exchange,
-      similarity: mode === 'text' ? undefined : 1 - row.distance,
+      similarity: mode === 'text' ? undefined : normalizedL2DistanceToSimilarity(row.distance),
       snippet,
       summary
     } as SearchResult & { summary?: string };
@@ -339,4 +344,3 @@ export async function formatMultiConceptResults(
 
   return output;
 }
-

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -113,10 +113,11 @@ describe('Integration Tests', () => {
 
       if (results.length > 0) {
         expect(results[0].similarity).toBeDefined();
-        // Similarity is 1 - distance, where distance can be > 1 for dissimilar items
-        // So similarity can be negative (valid for poor matches)
+        // sqlite-vec returns normalized L2 distance, which we convert back into
+        // cosine similarity. That keeps scores in the standard [-1, 1] range.
         expect(typeof results[0].similarity).toBe('number');
         expect(results[0].similarity).toBeLessThanOrEqual(1);
+        expect(results[0].similarity).toBeGreaterThanOrEqual(-1);
       }
     });
 

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { normalizedL2DistanceToSimilarity } from '../src/search.js';
+
+describe('normalizedL2DistanceToSimilarity', () => {
+  it('returns 1 for identical vectors', () => {
+    expect(normalizedL2DistanceToSimilarity(0)).toBe(1);
+  });
+
+  it('returns 0 for orthogonal vectors', () => {
+    expect(normalizedL2DistanceToSimilarity(Math.sqrt(2))).toBeCloseTo(0, 10);
+  });
+
+  it('returns -1 for opposite vectors', () => {
+    expect(normalizedL2DistanceToSimilarity(2)).toBe(-1);
+  });
+
+  it('clamps tiny floating point spillover into the valid cosine range', () => {
+    expect(normalizedL2DistanceToSimilarity(2.0000001)).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Summary
- convert normalized sqlite-vec L2 distances back into cosine similarity scores before formatting search results
- clamp the converted score into the valid `[-1, 1]` range to absorb tiny floating-point spillover
- add focused coverage for the distance-to-similarity helper and update the integration expectation to match the corrected score range

## Validation
- `npx vitest run test/search.test.ts`
- `npm run build`

Closes #55