### PR TITLE
fix: quote the SessionStart hook path for Windows home directories with spaces

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/cli/episodic-memory.js sync --background",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/cli/episodic-memory.js\" sync --background",
             "async": true
           }
         ]

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+
+describe('plugin hook configuration', () => {
+  it('quotes CLAUDE_PLUGIN_ROOT in the SessionStart command', () => {
+    const hooks = JSON.parse(
+      readFileSync(new URL('../hooks/hooks.json', import.meta.url), 'utf-8')
+    );
+
+    const command = hooks.hooks.SessionStart[0].hooks[0].command;
+
+    expect(command).toBe('node "${CLAUDE_PLUGIN_ROOT}/cli/episodic-memory.js" sync --background');
+  });
+});


### PR DESCRIPTION
## Summary
- quote `${CLAUDE_PLUGIN_ROOT}/cli/episodic-memory.js` in `hooks/hooks.json` so the SessionStart hook survives shell word-splitting on Windows paths with spaces
- add a regression test that loads the hook config and asserts the command stays quoted

## Validation
- `npx vitest run test/hooks.test.ts`
- `jq . hooks/hooks.json >/dev/null`

Closes #75