### PR TITLE
fix: remove --prefer-offline from MCP wrapper npm install (#76)

### DIFF
--- a/cli/mcp-server-wrapper.js
+++ b/cli/mcp-server-wrapper.js
@@ -25,7 +25,7 @@ function runNpmInstall() {
     console.error('This may take 30-60 seconds...');
 
     // Install dependencies - npm will auto-install optionalDependencies for current platform
-    const child = spawn(npmCommand, ['install', '--prefer-offline', '--no-audit', '--no-fund'], {
+    const child = spawn(npmCommand, ['install', '--no-audit', '--no-fund'], {
       cwd: PLUGIN_ROOT,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: isWindows // On Windows, we need shell: true to find npm.cmd


### PR DESCRIPTION
Fixes #76.

## What changed

Removed `--prefer-offline` from the `npm install` invocation in `cli/mcp-server-wrapper.js`. The `--no-audit` and `--no-fund` flags are kept.

## Why this matters

`--prefer-offline` tells npm to skip the registry whenever local cache metadata is present, even if that metadata is stale. The plugin's `better-sqlite3` dependency range is `^12.4.1`. On a fresh install where the user's npm cache predates that range, `--prefer-offline` makes npm refuse to refresh, and the install fails with:

```
npm error code ETARGET
npm error notarget No matching version found for better-sqlite3@^12.4.1.
```

The MCP server never starts and Claude Code surfaces `Failed to reconnect to plugin:episodic-memory:episodic-memory`. The reporter (DarkbyteAT in #76) confirmed that simply removing the flag makes the install succeed in ~13 seconds with no other changes.

## Why drop it rather than work around it

The flag's only benefit is shaving registry round-trips on a path that already only runs once (when `node_modules/` does not exist). Trading a one-time install latency improvement for a hard failure mode on stale caches is not worth it for a wrapper that gates the entire plugin from starting.

## Verification

- `node -c cli/mcp-server-wrapper.js` parses cleanly.
- Diff is one line; no behavior change beyond removing the flag.