### PR TITLE
fix: sync silently stops summarizing when zero-exchange files queue up

### DIFF
--- a/dist/sync.js
+++ b/dist/sync.js
@@ -154,7 +154,10 @@ export async function syncConversations(sourceDir, destDir, options = {}) {
                 const project = path.basename(path.dirname(filePath));
                 const exchanges = await parseConversation(filePath, project, filePath);
                 if (exchanges.length === 0) {
-                    continue; // Skip empty conversations
+                    // Skip empty conversations — write an empty -summary.txt sentinel so they aren't re-queued forever
+                    const summaryPath = filePath.replace('.jsonl', '-summary.txt');
+                    fs.writeFileSync(summaryPath, '', 'utf-8');
+                    continue;
                 }
                 console.log(`  Summarizing ${path.basename(filePath)} (${exchanges.length} exchanges)...`);
                 const summary = await summarizeConversation(exchanges, sessionId);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -200,7 +200,10 @@ export async function syncConversations(
         const exchanges = await parseConversation(filePath, project, filePath);
 
         if (exchanges.length === 0) {
-          continue; // Skip empty conversations
+          // Skip empty conversations — write an empty -summary.txt sentinel so they aren't re-queued forever
+          const summaryPath = filePath.replace('.jsonl', '-summary.txt');
+          fs.writeFileSync(summaryPath, '', 'utf-8');
+          continue;
         }
 
         console.log(`  Summarizing ${path.basename(filePath)} (${exchanges.length} exchanges)...`);

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, utimesSync, existsSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, utimesSync, existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { syncConversations } from '../src/sync.js';
@@ -207,5 +207,44 @@ describe('sync command', () => {
     dbCheck.close();
 
     expect(count.count).toBe(1); // Only normal conversation indexed
+  });
+
+  it('writes an empty summary sentinel for zero-exchange files so they do not re-queue forever', async () => {
+    mkdirSync(join(sourceDir, 'project-a'), { recursive: true });
+
+    // Stage more than summaryLimit (default 10) zero-exchange files — file-history-snapshot is a metadata record the parser drops.
+    const zeroExchangeFileCount = 12;
+    for (let i = 0; i < zeroExchangeFileCount; i++) {
+      const id = `1111aaaa-1111-1111-1111-${String(i).padStart(12, '0')}`;
+      const content = JSON.stringify({
+        type: 'file-history-snapshot',
+        sessionId: id,
+        uuid: `meta-${i}`,
+        timestamp: '2025-10-01T12:00:00Z'
+      });
+      writeFileSync(join(sourceDir, 'project-a', `${id}.jsonl`), content, 'utf-8');
+    }
+
+    // First sync: sentinel up to summaryLimit (default 10).
+    const r1 = await syncConversations(sourceDir, destDir, { skipIndex: true });
+    expect(r1.copied).toBe(zeroExchangeFileCount);
+    expect(r1.summarized).toBe(0);
+
+    const sentinelsAfter1 = readdirSync(join(destDir, 'project-a'))
+      .filter(f => f.endsWith('-summary.txt'));
+    expect(sentinelsAfter1.length).toBeGreaterThanOrEqual(10);
+
+    // Sentinels must be empty — that's how future syncs know to skip the file.
+    for (const s of sentinelsAfter1) {
+      expect(statSync(join(destDir, 'project-a', s)).size).toBe(0);
+    }
+
+    // Second sync drains the rest. Before the fix the same 10 would re-queue forever.
+    const r2 = await syncConversations(sourceDir, destDir, { skipIndex: true });
+    expect(r2.summarized).toBe(0);
+
+    const sentinelsAfter2 = readdirSync(join(destDir, 'project-a'))
+      .filter(f => f.endsWith('-summary.txt'));
+    expect(sentinelsAfter2.length).toBe(zeroExchangeFileCount);
   });
 });


### PR DESCRIPTION
## Summary

The summary loop in `syncConversations` silently `continue`s on files that `parseConversation` resolves to zero exchanges, without writing a `*-summary.txt`. Since the file-selection rule is "no summary file exists," every such file re-queues on every sync. Once `summaryLimit` of them accumulates at the head of iteration order, `slice(0, summaryLimit)` is entirely zombies — and real conversations behind them become unreachable.

A file resolves to zero exchanges in several legitimate cases (none are corruption): the file contains only metadata records (no `user`/`assistant` at all); `ai-title`-only stubs; sidechain Warmup stubs where the user record has no paired assistant; or files where the only `user` records are tool-results-only and get dropped by the parser. None of these have semantic content to summarize.

The fix writes an empty `*-summary.txt` as a sentinel that the existing `fs.existsSync(summaryPath)` selection check picks up unchanged — no read-side update required. No backfill is needed on existing installs: accumulated zero-exchange files drain through normal sync runs.

## How to reproduce

1. Have at least `summaryLimit` (default 10) `.jsonl` files in early iteration order that `parseConversation` resolves to zero exchanges.
2. Run `episodic-memory sync` repeatedly.
3. Observe `Generating summaries for 10 conversation(s)...` followed immediately by `Summarized: 0` and the `(N more need summaries)` counter pinned across runs. No per-file `Summarizing <file>...` line appears between them — that's the fingerprint.

## Test plan

- [x] New regression test in `test/sync.test.ts` stages 12 zero-exchange `.jsonl` files (more than the default `summaryLimit`), runs sync twice, asserts:
  - All 12 files get empty `-summary.txt` sentinels after the two syncs
  - Each sentinel is exactly 0 bytes (the signal future syncs use to skip)
  - `result.summarized === 0` on both runs (no real summaries were produced; LLM was never invoked)
- [x] Full test suite passes (one pre-existing failure in `test/show.test.ts:186` — the assertion `expect(markdown).toMatch(/9\/19\/2025|2025-09-19/)` is locale-sensitive and fails on non-US locales; reproduces on `main` with no PR changes)
- [x] `dist/sync.js` regenerated from `tsc` and committed alongside `src/sync.ts` per the repo's release rule
- [x] Verified on a live install: drained a ~1,500-entry backlog of `ai-title` stubs to 0 entirely via the patched code
