### PR TITLE
fix: sync queue stalls on short sessions from other project directories

### DIFF
--- a/dist/summarizer.d.ts
+++ b/dist/summarizer.d.ts
@@ -1,4 +1,19 @@
 import { ConversationExchange } from './types.js';
+/**
+ * Thrown by callClaude when the SDK yields an `is_error: true` result message.
+ * Carries the SDK's `subtype` and `session_id` as typed fields so callers can
+ * dispatch on structural metadata rather than parsing error message text.
+ */
+export declare class SummarizerSdkError extends Error {
+    readonly subtype: string;
+    readonly sessionId?: string | undefined;
+    constructor(subtype: string, sessionId?: string | undefined);
+}
+/**
+ * True when the SDK's reported failure subtype indicates resume couldn't find
+ * the session — the trigger for the non-resume fallback in summarizeConversation.
+ */
+export declare function isResumeFailure(error: unknown): boolean;
 export interface CodexSummarizerCommand {
     command: string;
     args: string[];
@@ -40,6 +55,7 @@ export declare function formatConversationText(exchanges: ConversationExchange[]
 export declare function buildSummarizerQueryOptions(args: {
     model: string;
     sessionId?: string;
+    cwd?: string;
 }): Record<string, unknown>;
 export declare function buildCodexSummaryPrompt(): string;
 export declare function buildCodexSummarizerCommand(args: {

--- a/dist/summarizer.js
+++ b/dist/summarizer.js
@@ -1,9 +1,32 @@
+import fs from 'fs';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { SUMMARIZER_CONTEXT_MARKER } from './constants.js';
 import { VERSION } from './version.js';
 import { spawn } from 'child_process';
 import { createInterface } from 'readline';
 import { codexVersionRequirementMessage, parseCodexCliVersion, versionMeetsMinimum, } from './codex-support.js';
+/**
+ * Thrown by callClaude when the SDK yields an `is_error: true` result message.
+ * Carries the SDK's `subtype` and `session_id` as typed fields so callers can
+ * dispatch on structural metadata rather than parsing error message text.
+ */
+export class SummarizerSdkError extends Error {
+    subtype;
+    sessionId;
+    constructor(subtype, sessionId) {
+        super(`Summarizer SDK error: ${subtype}${sessionId ? ` (session ${sessionId})` : ''}`);
+        this.subtype = subtype;
+        this.sessionId = sessionId;
+        this.name = 'SummarizerSdkError';
+    }
+}
+/**
+ * True when the SDK's reported failure subtype indicates resume couldn't find
+ * the session — the trigger for the non-resume fallback in summarizeConversation.
+ */
+export function isResumeFailure(error) {
+    return error instanceof SummarizerSdkError && error.subtype === 'error_during_execution';
+}
 /**
  * Get API environment overrides for summarization calls.
  * Returns full env merged with process.env so subprocess inherits PATH, HOME, etc.
@@ -64,13 +87,15 @@ function extractSummary(text) {
  * by claude-agent-sdk >= 0.2.0.
  */
 export function buildSummarizerQueryOptions(args) {
-    const { model, sessionId } = args;
+    const { model, sessionId, cwd } = args;
     return {
         model,
         max_tokens: 4096,
         env: getApiEnv(),
         resume: sessionId,
         persistSession: false,
+        // Resume looks up the session under ~/.claude/projects/<encoded-cwd>/, so pass the recorded cwd when it still exists on disk.
+        ...(cwd && fs.existsSync(cwd) ? { cwd } : {}),
         // Don't override systemPrompt when resuming — the resumed session's prompt stays in effect.
         ...(sessionId ? {} : {
             systemPrompt: 'Write concise, factual summaries. Output ONLY the summary - no preamble, no "Here is", no "I will". Your output will be indexed directly.'
@@ -112,21 +137,25 @@ export function buildCodexSummarizerCommand(args) {
         model: args.model,
     };
 }
-async function callClaude(prompt, sessionId, useFallback = false) {
+async function callClaude(prompt, sessionId, useFallback = false, cwd) {
     const primaryModel = process.env.EPISODIC_MEMORY_API_MODEL || 'haiku';
     const fallbackModel = process.env.EPISODIC_MEMORY_API_MODEL_FALLBACK || 'sonnet';
     const model = useFallback ? fallbackModel : primaryModel;
     for await (const message of query({
         prompt,
-        options: buildSummarizerQueryOptions({ model, sessionId }),
+        options: buildSummarizerQueryOptions({ model, sessionId, cwd }),
     })) {
         if (message && typeof message === 'object' && 'type' in message && message.type === 'result') {
+            // Throw on is_error — otherwise we return `message.result` (undefined) and the SDK's later iterator throw never fires.
+            if (message.is_error) {
+                throw new SummarizerSdkError(message.subtype || 'unknown', message.session_id);
+            }
             const result = message.result;
             // Check if result is an API error (SDK returns errors as result strings)
             if (typeof result === 'string' && result.includes('API Error') && result.includes('thinking.budget_tokens')) {
                 if (!useFallback) {
                     console.log(`    ${primaryModel} hit thinking budget error, retrying with ${fallbackModel}`);
-                    return await callClaude(prompt, sessionId, true);
+                    return await callClaude(prompt, sessionId, true, cwd);
                 }
                 // If fallback also fails, return error message
                 return result;
@@ -374,6 +403,7 @@ export async function summarizeConversation(exchanges, sessionId) {
     // For short conversations (≤15 exchanges), summarize directly
     if (exchanges.length <= 15) {
         const claudeSessionId = codexSessionId ? undefined : sessionId;
+        const cwd = claudeSessionId ? exchanges.find(e => e.cwd)?.cwd : undefined;
         const conversationText = claudeSessionId
             ? '' // When resuming, no need to include conversation text - it's already in context
             : formatConversationText(exchanges);
@@ -400,8 +430,20 @@ Bad:
 <summary>I apologize. The conversation discussed authentication and various approaches were considered...</summary>
 
 ${conversationText}`;
-        const result = await callClaude(prompt, claudeSessionId);
-        return extractSummary(result);
+        try {
+            const result = await callClaude(prompt, claudeSessionId, false, cwd);
+            return extractSummary(result);
+        }
+        catch (error) {
+            // Resume fails when the session's cwd doesn't exist on disk — retry without resume and feed the conversation text directly.
+            if (claudeSessionId && isResumeFailure(error)) {
+                console.log(`    resume failed for ${claudeSessionId} (${error.message}); retrying without resume`);
+                const fullPrompt = prompt + '\n\n' + formatConversationText(exchanges);
+                const result = await callClaude(fullPrompt);
+                return extractSummary(result);
+            }
+            throw error;
+        }
     }
     // For long conversations, use hierarchical summarization
     console.log(`  Long conversation (${exchanges.length} exchanges) - using hierarchical summarization`);

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { ConversationExchange } from './types.js';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { SUMMARIZER_CONTEXT_MARKER } from './constants.js';
@@ -9,6 +10,26 @@ import {
   parseCodexCliVersion,
   versionMeetsMinimum,
 } from './codex-support.js';
+
+/**
+ * Thrown by callClaude when the SDK yields an `is_error: true` result message.
+ * Carries the SDK's `subtype` and `session_id` as typed fields so callers can
+ * dispatch on structural metadata rather than parsing error message text.
+ */
+export class SummarizerSdkError extends Error {
+  constructor(public readonly subtype: string, public readonly sessionId?: string) {
+    super(`Summarizer SDK error: ${subtype}${sessionId ? ` (session ${sessionId})` : ''}`);
+    this.name = 'SummarizerSdkError';
+  }
+}
+
+/**
+ * True when the SDK's reported failure subtype indicates resume couldn't find
+ * the session — the trigger for the non-resume fallback in summarizeConversation.
+ */
+export function isResumeFailure(error: unknown): boolean {
+  return error instanceof SummarizerSdkError && error.subtype === 'error_during_execution';
+}
 
 export interface CodexSummarizerCommand {
   command: string;
@@ -87,14 +108,17 @@ function extractSummary(text: string): string {
 export function buildSummarizerQueryOptions(args: {
   model: string;
   sessionId?: string;
+  cwd?: string;
 }): Record<string, unknown> {
-  const { model, sessionId } = args;
+  const { model, sessionId, cwd } = args;
   return {
     model,
     max_tokens: 4096,
     env: getApiEnv(),
     resume: sessionId,
     persistSession: false,
+    // Resume looks up the session under ~/.claude/projects/<encoded-cwd>/, so pass the recorded cwd when it still exists on disk.
+    ...(cwd && fs.existsSync(cwd) ? { cwd } : {}),
     // Don't override systemPrompt when resuming — the resumed session's prompt stays in effect.
     ...(sessionId ? {} : {
       systemPrompt: 'Write concise, factual summaries. Output ONLY the summary - no preamble, no "Here is", no "I will". Your output will be indexed directly.'
@@ -145,23 +169,27 @@ export function buildCodexSummarizerCommand(args: {
   };
 }
 
-async function callClaude(prompt: string, sessionId?: string, useFallback = false): Promise<string> {
+async function callClaude(prompt: string, sessionId?: string, useFallback = false, cwd?: string): Promise<string> {
   const primaryModel = process.env.EPISODIC_MEMORY_API_MODEL || 'haiku';
   const fallbackModel = process.env.EPISODIC_MEMORY_API_MODEL_FALLBACK || 'sonnet';
   const model = useFallback ? fallbackModel : primaryModel;
 
   for await (const message of query({
     prompt,
-    options: buildSummarizerQueryOptions({ model, sessionId }) as any,
+    options: buildSummarizerQueryOptions({ model, sessionId, cwd }) as any,
   })) {
     if (message && typeof message === 'object' && 'type' in message && message.type === 'result') {
+      // Throw on is_error — otherwise we return `message.result` (undefined) and the SDK's later iterator throw never fires.
+      if ((message as any).is_error) {
+        throw new SummarizerSdkError((message as any).subtype || 'unknown', (message as any).session_id);
+      }
       const result = (message as any).result;
 
       // Check if result is an API error (SDK returns errors as result strings)
       if (typeof result === 'string' && result.includes('API Error') && result.includes('thinking.budget_tokens')) {
         if (!useFallback) {
           console.log(`    ${primaryModel} hit thinking budget error, retrying with ${fallbackModel}`);
-          return await callClaude(prompt, sessionId, true);
+          return await callClaude(prompt, sessionId, true, cwd);
         }
         // If fallback also fails, return error message
         return result;
@@ -444,6 +472,7 @@ export async function summarizeConversation(exchanges: ConversationExchange[], s
   // For short conversations (≤15 exchanges), summarize directly
   if (exchanges.length <= 15) {
     const claudeSessionId = codexSessionId ? undefined : sessionId;
+    const cwd = claudeSessionId ? exchanges.find(e => e.cwd)?.cwd : undefined;
     const conversationText = claudeSessionId
       ? '' // When resuming, no need to include conversation text - it's already in context
       : formatConversationText(exchanges);
@@ -472,8 +501,19 @@ Bad:
 
 ${conversationText}`;
 
-    const result = await callClaude(prompt, claudeSessionId);
-    return extractSummary(result);
+    try {
+      const result = await callClaude(prompt, claudeSessionId, false, cwd);
+      return extractSummary(result);
+    } catch (error) {
+      // Resume fails when the session's cwd doesn't exist on disk — retry without resume and feed the conversation text directly.
+      if (claudeSessionId && isResumeFailure(error)) {
+        console.log(`    resume failed for ${claudeSessionId} (${(error as Error).message}); retrying without resume`);
+        const fullPrompt = prompt + '\n\n' + formatConversationText(exchanges);
+        const result = await callClaude(fullPrompt);
+        return extractSummary(result);
+      }
+      throw error;
+    }
   }
 
   // For long conversations, use hierarchical summarization

--- a/test/summarizer-options.test.ts
+++ b/test/summarizer-options.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import {
   buildCodexSummaryPrompt,
   buildCodexSummarizerCommand,
   buildSummarizerQueryOptions,
   getApiEnv,
+  isResumeFailure,
   runCodexCommand,
-  shouldSkipReentrantSync
+  shouldSkipReentrantSync,
+  SummarizerSdkError
 } from '../src/summarizer.js';
 
 describe('buildSummarizerQueryOptions', () => {
@@ -29,6 +34,52 @@ describe('buildSummarizerQueryOptions', () => {
     const opts = buildSummarizerQueryOptions({ model: 'haiku', sessionId: 'abc-123' });
     expect(opts.resume).toBe('abc-123');
     expect(opts.systemPrompt).toBeUndefined();
+  });
+
+  it('passes cwd through to the SDK so resume looks up the session under the correct project dir', () => {
+    // The session's cwd must exist on disk for the option to be honored.
+    const realCwd = mkdtempSync(join(tmpdir(), 'episodic-memory-cwd-test-'));
+    try {
+      const opts = buildSummarizerQueryOptions({ model: 'haiku', sessionId: 'abc-123', cwd: realCwd });
+      expect(opts.cwd).toBe(realCwd);
+    } finally {
+      rmSync(realCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('omits cwd when the session\'s recorded cwd no longer exists on disk', () => {
+    const opts = buildSummarizerQueryOptions({
+      model: 'haiku',
+      sessionId: 'abc-123',
+      cwd: '/nonexistent/path/that/definitely/does/not/exist'
+    });
+    expect(opts.cwd).toBeUndefined();
+  });
+
+  it('omits cwd when not provided', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku', sessionId: 'abc-123' });
+    expect(opts.cwd).toBeUndefined();
+  });
+});
+
+describe('isResumeFailure', () => {
+  it('matches SummarizerSdkError with subtype error_during_execution (the SDK\'s signal for resume lookup failure)', () => {
+    expect(isResumeFailure(new SummarizerSdkError('error_during_execution'))).toBe(true);
+    expect(isResumeFailure(new SummarizerSdkError('error_during_execution', 'session-id-x'))).toBe(true);
+  });
+
+  it('does not match SummarizerSdkError with other subtypes', () => {
+    expect(isResumeFailure(new SummarizerSdkError('auth_failed'))).toBe(false);
+    expect(isResumeFailure(new SummarizerSdkError('rate_limit'))).toBe(false);
+    expect(isResumeFailure(new SummarizerSdkError('unknown'))).toBe(false);
+  });
+
+  it('does not match plain Error or non-Error values, even if their text looks resume-related', () => {
+    expect(isResumeFailure(new Error('No conversation found with session ID: abc'))).toBe(false);
+    expect(isResumeFailure(new Error('error_during_execution'))).toBe(false);
+    expect(isResumeFailure('No conversation found')).toBe(false);
+    expect(isResumeFailure(undefined)).toBe(false);
+    expect(isResumeFailure(null)).toBe(false);
   });
 });
 

--- a/test/summarizer-resume-fallback.test.ts
+++ b/test/summarizer-resume-fallback.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { ConversationExchange } from '../src/types.js';
+
+// Stub the SDK's query() so each test controls what messages it yields.
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { summarizeConversation, SummarizerSdkError } from '../src/summarizer.js';
+
+function asyncIterableFor(sdkMessages: unknown[]): AsyncIterable<unknown> {
+  return {
+    [Symbol.asyncIterator]() {
+      let i = 0;
+      return {
+        next() {
+          if (i < sdkMessages.length) {
+            return Promise.resolve({ value: sdkMessages[i++], done: false });
+          }
+          return Promise.resolve({ value: undefined, done: true });
+        },
+      };
+    },
+  };
+}
+
+function makeExchange(overrides: Partial<ConversationExchange> = {}): ConversationExchange {
+  return {
+    id: 'ex-1',
+    project: 'test-project',
+    timestamp: '2025-10-01T12:00:00Z',
+    userMessage: 'How do I rebase against origin/main?',
+    assistantMessage: 'Use git rebase origin/main from your feature branch.',
+    archivePath: '/tmp/archive/test.jsonl',
+    lineStart: 1,
+    lineEnd: 2,
+    sessionId: 'abc-123',
+    cwd: '/tmp/nonexistent-cwd-for-test',
+    ...overrides,
+  };
+}
+
+describe('summarizeConversation — Claude resume fallback (cwd-mismatch recovery)', () => {
+  beforeEach(() => {
+    vi.mocked(query).mockReset();
+  });
+
+  it('propagates SDK is_error results as SummarizerSdkError when the fallback also fails', async () => {
+    vi.mocked(query)
+      .mockReturnValueOnce(asyncIterableFor([
+        { type: 'result', is_error: true, subtype: 'error_during_execution' },
+      ]) as any)
+      .mockReturnValueOnce(asyncIterableFor([
+        { type: 'result', is_error: true, subtype: 'error_during_execution' },
+      ]) as any);
+
+    await expect(summarizeConversation([makeExchange()], 'abc-123'))
+      .rejects.toBeInstanceOf(SummarizerSdkError);
+  });
+
+  it('attaches the SDK subtype and session_id to the thrown SummarizerSdkError', async () => {
+    vi.mocked(query).mockReturnValueOnce(asyncIterableFor([
+      { type: 'result', is_error: true, subtype: 'auth_failed', session_id: 'sdk-session-id-xyz' },
+    ]) as any);
+
+    let caught: unknown;
+    try {
+      await summarizeConversation([makeExchange()], 'abc-123');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SummarizerSdkError);
+    expect((caught as SummarizerSdkError).subtype).toBe('auth_failed');
+    expect((caught as SummarizerSdkError).sessionId).toBe('sdk-session-id-xyz');
+  });
+
+  it('retries without resume when the first call fails with is_error, returning the second call\'s summary', async () => {
+    vi.mocked(query)
+      .mockReturnValueOnce(asyncIterableFor([
+        { type: 'result', is_error: true, subtype: 'error_during_execution' },
+      ]) as any)
+      .mockReturnValueOnce(asyncIterableFor([
+        { type: 'result', is_error: false, result: '<summary>Recovered summary text.</summary>' },
+      ]) as any);
+
+    const result = await summarizeConversation([makeExchange()], 'abc-123');
+    expect(result).toBe('Recovered summary text.');
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(2);
+
+    const firstCallOptions = vi.mocked(query).mock.calls[0][0].options as any;
+    expect(firstCallOptions.resume).toBe('abc-123');
+
+    // The fallback omits resume so the SDK opens a fresh session, and the
+    // prompt grows to include the conversation text the fresh session needs.
+    const secondCallOptions = vi.mocked(query).mock.calls[1][0].options as any;
+    expect(secondCallOptions.resume).toBeUndefined();
+    const secondPrompt = vi.mocked(query).mock.calls[1][0].prompt as string;
+    expect(secondPrompt).toContain('How do I rebase against origin/main?');
+    expect(secondPrompt).toContain('Use git rebase origin/main');
+  });
+
+  it('passes the session\'s recorded cwd to the SDK when the path still exists on disk', async () => {
+    const realCwd = mkdtempSync(join(tmpdir(), 'episodic-memory-cwd-test-'));
+    try {
+      vi.mocked(query).mockReturnValueOnce(asyncIterableFor([
+        { type: 'result', is_error: false, result: '<summary>ok</summary>' },
+      ]) as any);
+
+      await summarizeConversation([makeExchange({ cwd: realCwd })], 'abc-123');
+
+      const opts = vi.mocked(query).mock.calls[0][0].options as any;
+      expect(opts.cwd).toBe(realCwd);
+      expect(opts.resume).toBe('abc-123');
+    } finally {
+      rmSync(realCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('omits cwd from SDK options when the session\'s recorded cwd no longer exists (dead worktree)', async () => {
+    vi.mocked(query).mockReturnValueOnce(asyncIterableFor([
+      { type: 'result', is_error: false, result: '<summary>ok</summary>' },
+    ]) as any);
+
+    await summarizeConversation([makeExchange({ cwd: '/definitely/not/here' })], 'abc-123');
+
+    const opts = vi.mocked(query).mock.calls[0][0].options as any;
+    expect(opts.cwd).toBeUndefined();
+    expect(opts.resume).toBe('abc-123');
+  });
+
+  it('does not retry when the SDK throws a non-resume error', async () => {
+    vi.mocked(query).mockImplementationOnce(() => {
+      throw new Error('Network unreachable');
+    });
+
+    await expect(summarizeConversation([makeExchange()], 'abc-123'))
+      .rejects.toThrow(/Network unreachable/);
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry when the SDK yields is_error with a subtype isResumeFailure rejects', async () => {
+    // Non-resume subtypes must propagate without firing the fallback.
+    vi.mocked(query).mockReturnValueOnce(asyncIterableFor([
+      { type: 'result', is_error: true, subtype: 'auth_failed' },
+    ]) as any);
+
+    await expect(summarizeConversation([makeExchange()], 'abc-123'))
+      .rejects.toBeInstanceOf(SummarizerSdkError);
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Sync queue stalls on short sessions from other project directories

## Description

In a normal SessionStart-triggered sync, short sessions (≤15 exchanges) archived from any project other than the one the sync process is running in silently fail to summarize. The sync's catch writes no `*-summary.txt`, so failed files re-queue every run. With `summaryLimit: 10`, once ten such failures accumulate at the head of the queue, real conversations behind them are never reached — same stall pattern as the zero-exchange zombie fix in 1.4.1, different trigger.

Log fingerprint:

```
✅ Sync complete!
  Summarized: 0
⚠️  Errors: 4
  <archive>/<project>/<uuid>.jsonl:
    Summary generation failed: Cannot read properties of undefined (reading 'match')
  ...
💡 All N summarization attempts failed.
  Check your API configuration (EPISODIC_MEMORY_API_BASE_URL / ANTHROPIC_API_KEY).
```

Two things are misleading: the API is fine, and `Cannot read properties of undefined` is a *secondary* crash. The actual SDK error (`No conversation found with session ID: ...`) is swallowed before it can propagate to the user-facing log.

This wasn't visible to most users on ≤1.4.0 because zero-exchange zombies were absorbing the queue head first. Now that 1.4.1 drains those, cwd-mismatch failures are the new front of the queue — effectively a regression that 1.4.1 exposes.

Mitigating factor: only sessions ≤15 exchanges take the resume path. Longer sessions include the conversation text directly and don't resume, so they're unaffected.

Distinct from the zero-exchange zombie fingerprint:

- `Summarizing <file> (K exchanges)...` lines appear (parser produced exchanges),
- followed by `Summarized: 0` and a non-empty `⚠️ Errors` block,
- and the same files re-appear in every subsequent sync.

## Environment

- episodic-memory v1.4.1
- `@anthropic-ai/claude-agent-sdk` bundled with v1.4.1

## Steps to Reproduce

1. Have any short session (≤15 exchanges) archived from project A.
2. Start a Claude Code session somewhere whose cwd differs from project A — SessionStart fires `episodic-memory sync --background` with that cwd.
3. Sync picks up the session-from-A file and tries to summarize it.
4. Observe `⚠️ Errors: N` with `Cannot read properties of undefined (reading 'match')`.
5. Re-run sync — same files, same errors, indefinitely.

## Root Cause

For short conversations (≤15 exchanges), `summarizeConversation` calls the Claude Agent SDK with `resume: sessionId` and *omits* the transcript text from the prompt — the resumed session is expected to provide context. Three coordinated issues then cascade:

**1. `buildSummarizerQueryOptions` does not set `cwd`.** The SDK spawns `claude` as a subprocess, which inherits the sync process's cwd. Claude Code resolves `resume: sessionId` against `~/.claude/projects/<encode(process.cwd())>/<sessionId>.jsonl`. If the session belongs to a different project, that file doesn't exist and the subprocess emits `type: 'result'` with `is_error: true` and `subtype: 'error_during_execution'`.

Verified directly with the bundled SDK against an archived session file. Same session ID, same options, same prompt — only cwd differs:

| cwd used to spawn | Result |
|---|---|
| Sync's cwd (≠ session's project) | `*** stream threw: No conversation found with session ID: ...` |
| The session's recorded project cwd | 9 messages streamed; real `<summary>` returned in ~5 s |

**2. `callClaude` swallows the SDK's error signal.** The current code matches `message.type === 'result'`, reads `message.result` (undefined on `is_error` results), and returns immediately. The SDK's iterator would have thrown a human-readable `"Claude Code returned an error result: No conversation found with session ID: ..."` on the next iteration, but the early return skips that. `callClaude` returns `undefined`, `extractSummary(undefined)` crashes with `Cannot read properties of undefined (reading 'match')`, and the actionable SDK error is unreachable.

**3. `sync.ts` writes no sentinel on failure.** The catch pushes to `result.errors` without creating a `*-summary.txt`, so the file remains in `filesToSummarize` on every subsequent sync — same forever-failure pattern as the zero-exchange zombie, different trigger.

## Why These Sessions Exist

cwd mismatch is the normal state for any multi-project install:

- **Active-project sessions.** The session's cwd still exists on disk; only the sync's cwd is wrong. Fully resumable when spawned with the right cwd.
- **Dead-worktree sessions.** The session's cwd no longer exists (worktree deleted, branch removed). Even chdir-ing can't recover these.
- **Multi-project sessions.** Sessions whose cwd-encoded paths collide ambiguously after archive copy.

Sessions outlive the cwds they came from — that's correct archive behavior. The bug is the summarizer's failure to handle the mismatch.

## Fix Summary

Three parts; see the diff for code.

1. **Pass the session's recorded `cwd` to the SDK** when the directory still exists on disk. The parser already exposes `cwd` on each exchange. Resolves the active-project case.
2. **Make `callClaude` throw `SummarizerSdkError` on SDK `is_error` results** instead of silently returning `undefined`. Prerequisite for (3) — without this, the resume failure is invisible to any catch-and-retry logic, and the only error to propagate is the secondary `Cannot read properties of undefined` from `extractSummary`, which doesn't pattern-match any resume signal.
3. **Fall back to non-resume on `isResumeFailure`** — retry once without `resume:` and include the conversation text in the prompt. Resolves the dead-worktree case where no cwd on disk can ever satisfy the SDK.

Tests added: `test/summarizer-options.test.ts` (pure-function coverage for the new `cwd` plumbing and `isResumeFailure`) and `test/summarizer-resume-fallback.test.ts` (integration coverage via a mocked SDK — error throw, fallback path with conversation text included, cwd-existence guards, non-resume errors propagating without firing the fallback).

## Fix Verified

Applied to a real install with 4 cwd-mismatch files pinning the queue (1 active project, 3 dead worktrees). Drain log:

```
Generating summaries for 4 conversation(s)...
  Summarizing <uuid-1>.jsonl (2 exchanges)...     [active project — Part 1]
  Summarizing <uuid-2>.jsonl (1 exchanges)...     [dead worktree — Part 3]
  Summarizing <uuid-3>.jsonl (8 exchanges)...     [dead worktree — Part 3]
  Summarizing <uuid-4>.jsonl (13 exchanges)...    [dead worktree — Part 3]
    resume failed for <uuid-4> (SummarizerSdkError: error_during_execution); retrying without resume

✅ Sync complete!
  Summarized: 4
```

All four cleared. The next sync had no `Generating summaries` line — queue fully drained.

Caveat: some fallback summaries return raw model output rather than `<summary></summary>`-wrapped text. The prompt was originally written for the resume case (where the system prompt belongs to the resumed session); when reused for the fallback, the model sometimes omits the wrapper. `extractSummary` falls back to returning the raw text — searchable and sentineled, but worth tightening if upstream wants summary uniformity.
