### PR TITLE
Fix Codex summarizer: ignore deprecated model from history; add env override

### DIFF
--- a/dist/mcp-server.js
+++ b/dist/mcp-server.js
@@ -26850,7 +26850,7 @@ ${result}
 }
 
 // src/version.ts
-var VERSION = "1.4.0";
+var VERSION = "1.4.1";
 
 // src/mcp-server.ts
 import fs4 from "fs";

--- a/dist/summarizer.d.ts
+++ b/dist/summarizer.d.ts
@@ -49,4 +49,20 @@ export declare function buildCodexSummarizerCommand(args: {
     codexBin?: string;
 }): CodexSummarizerCommand;
 export declare function runCodexCommand(command: CodexSummarizerCommand): Promise<string>;
+/**
+ * Resolve the model to pass into Codex `thread/fork` for summarization.
+ *
+ * Historical exchanges may carry deprecated model ids (e.g. `gpt-5.2-codex`),
+ * and `-codex`-suffixed variants are API-key-only — ChatGPT-subscription users
+ * get a 400 from `app-server` regardless of the suffix used. Reading the model
+ * from history therefore breaks summarization for two large user populations.
+ *
+ * Default to `undefined` so `app-server` uses the current Codex config
+ * (`~/.codex/config.toml#model`). Operators can override via
+ * `EPISODIC_MEMORY_CODEX_MODEL` if they need a specific model id (e.g. an
+ * API-key user wanting `gpt-5.5-codex`).
+ *
+ * See https://github.com/obra/episodic-memory/issues/98.
+ */
+export declare function getCodexModel(_exchanges: ConversationExchange[]): string | undefined;
 export declare function summarizeConversation(exchanges: ConversationExchange[], sessionId?: string): Promise<string>;

--- a/dist/summarizer.js
+++ b/dist/summarizer.js
@@ -347,8 +347,23 @@ function getCodexSessionId(exchanges, sessionId) {
     }
     return sessionId || exchanges.find(exchange => exchange.sessionId)?.sessionId;
 }
-function getCodexModel(exchanges) {
-    return exchanges.find(exchange => exchange.harness === 'codex' && exchange.model)?.model;
+/**
+ * Resolve the model to pass into Codex `thread/fork` for summarization.
+ *
+ * Historical exchanges may carry deprecated model ids (e.g. `gpt-5.2-codex`),
+ * and `-codex`-suffixed variants are API-key-only — ChatGPT-subscription users
+ * get a 400 from `app-server` regardless of the suffix used. Reading the model
+ * from history therefore breaks summarization for two large user populations.
+ *
+ * Default to `undefined` so `app-server` uses the current Codex config
+ * (`~/.codex/config.toml#model`). Operators can override via
+ * `EPISODIC_MEMORY_CODEX_MODEL` if they need a specific model id (e.g. an
+ * API-key user wanting `gpt-5.5-codex`).
+ *
+ * See https://github.com/obra/episodic-memory/issues/98.
+ */
+export function getCodexModel(_exchanges) {
+    return process.env.EPISODIC_MEMORY_CODEX_MODEL || undefined;
 }
 export async function summarizeConversation(exchanges, sessionId) {
     // Handle trivial conversations

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -414,8 +414,23 @@ function getCodexSessionId(exchanges: ConversationExchange[], sessionId?: string
   return sessionId || exchanges.find(exchange => exchange.sessionId)?.sessionId;
 }
 
-function getCodexModel(exchanges: ConversationExchange[]): string | undefined {
-  return exchanges.find(exchange => exchange.harness === 'codex' && exchange.model)?.model;
+/**
+ * Resolve the model to pass into Codex `thread/fork` for summarization.
+ *
+ * Historical exchanges may carry deprecated model ids (e.g. `gpt-5.2-codex`),
+ * and `-codex`-suffixed variants are API-key-only — ChatGPT-subscription users
+ * get a 400 from `app-server` regardless of the suffix used. Reading the model
+ * from history therefore breaks summarization for two large user populations.
+ *
+ * Default to `undefined` so `app-server` uses the current Codex config
+ * (`~/.codex/config.toml#model`). Operators can override via
+ * `EPISODIC_MEMORY_CODEX_MODEL` if they need a specific model id (e.g. an
+ * API-key user wanting `gpt-5.5-codex`).
+ *
+ * See https://github.com/obra/episodic-memory/issues/98.
+ */
+export function getCodexModel(_exchanges: ConversationExchange[]): string | undefined {
+  return process.env.EPISODIC_MEMORY_CODEX_MODEL || undefined;
 }
 
 export async function summarizeConversation(exchanges: ConversationExchange[], sessionId?: string): Promise<string> {

--- a/test/summarizer-options.test.ts
+++ b/test/summarizer-options.test.ts
@@ -4,9 +4,11 @@ import {
   buildCodexSummarizerCommand,
   buildSummarizerQueryOptions,
   getApiEnv,
+  getCodexModel,
   runCodexCommand,
   shouldSkipReentrantSync
 } from '../src/summarizer.js';
+import { ConversationExchange } from '../src/types.js';
 
 describe('buildSummarizerQueryOptions', () => {
   it('sets persistSession: false so the SDK does not write session JSONLs to ~/.claude/projects/ (#83)', () => {
@@ -125,6 +127,45 @@ describe('runCodexCommand', () => {
       prompt: 'Summarize this conversation.',
       skipVersionCheck: true,
     })).rejects.toThrow(/thread\/fork returned unexpected response/);
+  });
+});
+
+describe('getCodexModel', () => {
+  afterEach(() => {
+    delete process.env.EPISODIC_MEMORY_CODEX_MODEL;
+  });
+
+  const codexExchange = (model?: string): ConversationExchange => ({
+    id: 'ex-1',
+    project: 'test',
+    timestamp: '2026-04-01T00:00:00Z',
+    userMessage: 'hi',
+    assistantMessage: 'hello',
+    archivePath: '/tmp/test.jsonl',
+    lineStart: 1,
+    lineEnd: 2,
+    harness: 'codex',
+    model,
+  });
+
+  it('returns undefined by default so app-server falls back to ~/.codex/config.toml#model', () => {
+    expect(getCodexModel([codexExchange('gpt-5.2-codex')])).toBeUndefined();
+  });
+
+  it('ignores deprecated model ids baked into historical exchanges (#98)', () => {
+    // pre-deprecation Codex sessions carry model: "gpt-5.2-codex"; forcing that
+    // into thread/fork returns 400 "model is not supported".
+    expect(getCodexModel([codexExchange('gpt-5.2-codex')])).toBeUndefined();
+  });
+
+  it('honors EPISODIC_MEMORY_CODEX_MODEL when operators want a specific model', () => {
+    process.env.EPISODIC_MEMORY_CODEX_MODEL = 'gpt-5.5-codex';
+    expect(getCodexModel([codexExchange('gpt-5.2-codex')])).toBe('gpt-5.5-codex');
+  });
+
+  it('treats an empty EPISODIC_MEMORY_CODEX_MODEL the same as unset', () => {
+    process.env.EPISODIC_MEMORY_CODEX_MODEL = '';
+    expect(getCodexModel([codexExchange('gpt-5.2-codex')])).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- `getCodexModel()` now defaults to `undefined`, letting Codex's `app-server` fork pick the model from `~/.codex/config.toml`
- Operators who need a specific model id (e.g. API-key users wanting `gpt-5.5-codex`) can set `EPISODIC_MEMORY_CODEX_MODEL`
- Added four unit tests covering the default + env-override paths

## Why

Reading the model from historical exchanges breaks Codex summarization for two common populations — see #98 for the full repro. tl;dr:

1. Pre-deprecation Codex sessions carry `model: "gpt-5.2-codex"`, which `app-server` now rejects with `400 "model is not supported when using Codex with a ChatGPT account"`.
2. Any `-codex`-suffix variant (`gpt-5.5-codex`, etc.) is API-key-only — ChatGPT-subscription users get the **same** 400 regardless of which suffix is used. The error message is misleading; only base models (`gpt-5.5`, ...) are reachable via `app-server` fork for them.

In practice this dropped ~250 of my Codex transcripts into the `Codex summarizer unavailable, falling back to transcript text` path. After applying this change, the backlog drained cleanly on the next sync.

## Compat / behavior

- Default behavior changes: previously the historical model was passed to `thread/fork`; now nothing is passed unless `EPISODIC_MEMORY_CODEX_MODEL` is set. Codex falls back to `config.toml#model`, which is what `codex` itself uses interactively — same model the user sees in their UI.
- API-key users who were relying on the historical `-codex` variant being forwarded can restore that behavior with `EPISODIC_MEMORY_CODEX_MODEL=gpt-5.5-codex` (or whichever variant they want).

## Test plan

- [x] `npm test test/summarizer-options.test.ts` — 19/19 pass (4 new tests for `getCodexModel`)
- [x] `npm run build` — clean
- [x] Manual repro: ran `EPISODIC_MEMORY_CODEX_MODEL=gpt-5.5 episodic-memory sync` against an archive of 247 Codex transcripts originally summarized as `gpt-5.2-codex`. All summaries succeeded; backlog drained.
- Pre-existing failures on `main` in `test/show.test.ts` (hardcoded date `2025-09-19`) and `test/multi-concept.test.ts` (probabilistic ranking) are unrelated to this change.

Closes #98.