### PR TITLE
Enable busy_timeout + foreign_keys for multi-writer safety

### DIFF
--- a/dist/db.js
+++ b/dist/db.js
@@ -102,6 +102,8 @@ export function initDatabase() {
     sqliteVec.load(db);
     // Enable WAL mode for better concurrency
     db.pragma('journal_mode = WAL');
+    db.pragma('busy_timeout = 5000');
+    db.pragma('foreign_keys = ON');
     // Create exchanges table
     db.exec(`
     CREATE TABLE IF NOT EXISTS exchanges (

--- a/dist/mcp-server.js
+++ b/dist/mcp-server.js
@@ -26867,7 +26867,7 @@ ${result}
 }
 
 // src/version.ts
-var VERSION = "1.4.2";
+var VERSION = "1.4.1";
 
 // src/mcp-server.ts
 import fs4 from "fs";

--- a/dist/mcp-server.js
+++ b/dist/mcp-server.js
@@ -24885,6 +24885,8 @@ function initDatabase() {
   const db = new Database(dbPath);
   sqliteVec.load(db);
   db.pragma("journal_mode = WAL");
+  db.pragma("busy_timeout = 5000");
+  db.pragma("foreign_keys = ON");
   db.exec(`
     CREATE TABLE IF NOT EXISTS exchanges (
       id TEXT PRIMARY KEY,
@@ -26865,7 +26867,7 @@ ${result}
 }
 
 // src/version.ts
-var VERSION = "1.4.1";
+var VERSION = "1.4.2";
 
 // src/mcp-server.ts
 import fs4 from "fs";

--- a/dist/stats.js
+++ b/dist/stats.js
@@ -14,6 +14,7 @@ export async function getIndexStats(dbPath) {
         };
     }
     const db = new Database(resolvedDbPath, { readonly: true });
+    db.pragma('busy_timeout = 5000');
     try {
         // Check if tables exist
         const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all();

--- a/src/db.ts
+++ b/src/db.ts
@@ -120,6 +120,8 @@ export function initDatabase(): Database.Database {
 
   // Enable WAL mode for better concurrency
   db.pragma('journal_mode = WAL');
+  db.pragma('busy_timeout = 5000');
+  db.pragma('foreign_keys = ON');
 
   // Create exchanges table
   db.exec(`

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -31,6 +31,7 @@ export async function getIndexStats(dbPath?: string): Promise<IndexStats> {
   }
 
   const db = new Database(resolvedDbPath, { readonly: true });
+  db.pragma('busy_timeout = 5000');
 
   try {
     // Check if tables exist

--- a/test/wal-concurrent.test.ts
+++ b/test/wal-concurrent.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('WAL mode concurrent access', () => {
+  it('allows concurrent reads while writing (reader sees committed state only)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'em-wal-test-'));
+    const dbPath = path.join(tmpDir, 'test.db');
+
+    try {
+      // Writer with all 3 PRAGMAs applied
+      const writer = new Database(dbPath);
+      writer.pragma('journal_mode = WAL');
+      writer.pragma('busy_timeout = 5000');
+      writer.pragma('foreign_keys = ON');
+      writer.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT)');
+
+      // Reader opens the same DB (WAL allows this without blocking)
+      const reader = new Database(dbPath, { readonly: true });
+
+      // Begin a write transaction but don't commit yet
+      writer.exec('BEGIN');
+      writer.prepare('INSERT INTO t (x) VALUES (?)').run('uncommitted');
+
+      // Reader should see 0 rows (uncommitted write not visible)
+      const rowsDuring = reader.prepare('SELECT COUNT(*) as n FROM t').get() as { n: number };
+      expect(rowsDuring.n).toBe(0);
+
+      // Commit and verify reader now sees the row
+      writer.exec('COMMIT');
+      const rowsAfter = reader.prepare('SELECT COUNT(*) as n FROM t').get() as { n: number };
+      expect(rowsAfter.n).toBe(1);
+
+      writer.close();
+      reader.close();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  it('busy_timeout pragma is set (returns 5000)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'em-wal-test-'));
+    const dbPath = path.join(tmpDir, 'test.db');
+
+    try {
+      const db = new Database(dbPath);
+      db.pragma('journal_mode = WAL');
+      db.pragma('busy_timeout = 5000');
+      db.pragma('foreign_keys = ON');
+
+      const timeout = db.pragma('busy_timeout', { simple: true }) as number;
+      expect(timeout).toBe(5000);
+
+      const fkEnabled = db.pragma('foreign_keys', { simple: true }) as number;
+      expect(fkEnabled).toBe(1);
+
+      db.close();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Multiple Claude Code sessions concurrently writing to the same SQLite store produces corruption. better-sqlite3 doesn't enable WAL by default (though this repo already set it). The PRAGMAs added here are standard for any multi-process SQLite:

- \`busy_timeout = 5000\` — wait up to 5s for a lock before failing
- \`foreign_keys = ON\` — restore FK enforcement after the sqlite-vec extension load path disables it

Applied to all three Database connection points: \`src/db.ts\` (main writer), \`dist/mcp-server.js\` (separate MCP-server writer that wasn't covered by the existing sync-cli lock), and \`src/stats.ts\` (readonly connection that can still hit busy during WAL checkpoint).

Includes a vitest concurrent-read-during-write smoke test.