### PR TITLE
fix(summarizer): isolate MCP servers and settings in summarizer subprocess

### DIFF
--- a/dist/summarizer.d.ts
+++ b/dist/summarizer.d.ts
@@ -51,6 +51,14 @@ export declare function formatConversationText(exchanges: ConversationExchange[]
  * ~/.claude/projects/ (#83). Without it, every summarization spawns a fake
  * session JSONL that pollutes the IDE session sidebar. The option is honored
  * by claude-agent-sdk >= 0.2.0.
+ *
+ * settingSources: [] + mcpServers: {} isolate the summarizer subprocess from
+ * the user's environment (#106). The SDK loads all filesystem settings by
+ * default (~/.claude/settings.json, .mcp.json, ~/.claude.json mcpServers, ...),
+ * so without this every summarization boots the user's entire global MCP fleet
+ * — one set of MCP server subprocesses per conversation. Servers that open a
+ * GUI (e.g. Serena's dashboard) pop a window per conversation; the rest churn
+ * CPU/RAM silently. A summarizer needs no tools or MCP servers.
  */
 export declare function buildSummarizerQueryOptions(args: {
     model: string;

--- a/dist/summarizer.js
+++ b/dist/summarizer.js
@@ -85,6 +85,14 @@ function extractSummary(text) {
  * ~/.claude/projects/ (#83). Without it, every summarization spawns a fake
  * session JSONL that pollutes the IDE session sidebar. The option is honored
  * by claude-agent-sdk >= 0.2.0.
+ *
+ * settingSources: [] + mcpServers: {} isolate the summarizer subprocess from
+ * the user's environment (#106). The SDK loads all filesystem settings by
+ * default (~/.claude/settings.json, .mcp.json, ~/.claude.json mcpServers, ...),
+ * so without this every summarization boots the user's entire global MCP fleet
+ * — one set of MCP server subprocesses per conversation. Servers that open a
+ * GUI (e.g. Serena's dashboard) pop a window per conversation; the rest churn
+ * CPU/RAM silently. A summarizer needs no tools or MCP servers.
  */
 export function buildSummarizerQueryOptions(args) {
     const { model, sessionId, cwd } = args;
@@ -94,6 +102,12 @@ export function buildSummarizerQueryOptions(args) {
         env: getApiEnv(),
         resume: sessionId,
         persistSession: false,
+        // Isolate the subprocess from the user's settings/MCP servers (#106). The SDK
+        // otherwise loads all filesystem settings, so each summarization would boot the
+        // user's entire global MCP fleet — one set of MCP subprocesses per conversation.
+        // [] is the SDK's documented isolation mode; {} makes the empty server set explicit.
+        settingSources: [],
+        mcpServers: {},
         // Resume looks up the session under ~/.claude/projects/<encoded-cwd>/, so pass the recorded cwd when it still exists on disk.
         ...(cwd && fs.existsSync(cwd) ? { cwd } : {}),
         // Don't override systemPrompt when resuming — the resumed session's prompt stays in effect.

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -104,6 +104,14 @@ function extractSummary(text: string): string {
  * ~/.claude/projects/ (#83). Without it, every summarization spawns a fake
  * session JSONL that pollutes the IDE session sidebar. The option is honored
  * by claude-agent-sdk >= 0.2.0.
+ *
+ * settingSources: [] + mcpServers: {} isolate the summarizer subprocess from
+ * the user's environment (#106). The SDK loads all filesystem settings by
+ * default (~/.claude/settings.json, .mcp.json, ~/.claude.json mcpServers, ...),
+ * so without this every summarization boots the user's entire global MCP fleet
+ * — one set of MCP server subprocesses per conversation. Servers that open a
+ * GUI (e.g. Serena's dashboard) pop a window per conversation; the rest churn
+ * CPU/RAM silently. A summarizer needs no tools or MCP servers.
  */
 export function buildSummarizerQueryOptions(args: {
   model: string;
@@ -117,6 +125,12 @@ export function buildSummarizerQueryOptions(args: {
     env: getApiEnv(),
     resume: sessionId,
     persistSession: false,
+    // Isolate the subprocess from the user's settings/MCP servers (#106). The SDK
+    // otherwise loads all filesystem settings, so each summarization would boot the
+    // user's entire global MCP fleet — one set of MCP subprocesses per conversation.
+    // [] is the SDK's documented isolation mode; {} makes the empty server set explicit.
+    settingSources: [],
+    mcpServers: {},
     // Resume looks up the session under ~/.claude/projects/<encoded-cwd>/, so pass the recorded cwd when it still exists on disk.
     ...(cwd && fs.existsSync(cwd) ? { cwd } : {}),
     // Don't override systemPrompt when resuming — the resumed session's prompt stays in effect.

--- a/test/summarizer-options.test.ts
+++ b/test/summarizer-options.test.ts
@@ -21,6 +21,22 @@ describe('buildSummarizerQueryOptions', () => {
     expect(opts.persistSession).toBe(false);
   });
 
+  it('disables filesystem settings (settingSources: []) so the subprocess does not inherit the user\'s config (#106)', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku' });
+    expect(opts.settingSources).toEqual([]);
+  });
+
+  it('passes an empty mcpServers set so no MCP servers are spawned per conversation (#106)', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku' });
+    expect(opts.mcpServers).toEqual({});
+  });
+
+  it('keeps MCP/settings isolation on resumed sessions too — the path that runs in the SessionStart sync (#106)', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku', sessionId: 'abc-123' });
+    expect(opts.settingSources).toEqual([]);
+    expect(opts.mcpServers).toEqual({});
+  });
+
   it('passes through the model and max_tokens', () => {
     const opts = buildSummarizerQueryOptions({ model: 'haiku' });
     expect(opts.model).toBe('haiku');


### PR DESCRIPTION
## What

The background summarizer (`summarizer.ts` → `buildSummarizerQueryOptions`) runs each archived conversation through the Claude Agent SDK with `resume` + the conversation's `cwd`. The SDK loads **all** filesystem settings by default, so every summarization boots the user's entire global MCP server set — one MCP fleet spawned per conversation. MCP servers that open a GUI (e.g. [Serena](https://github.com/oraios/serena)'s web dashboard) pop a window per conversation; the rest start and tear down silently, churning CPU/RAM. With a backlog of N conversations, a single `SessionStart` sync fans out to N × (whole MCP fleet).

Same root mechanism as #83 (`resume` → full Claude Code session subprocess) and the MCP-config analog of #104 (summarizer inheriting global env).

## Change

Two options added to the summarizer's `query()`:

- **`settingSources: []`** — the SDK's documented isolation mode (*"Pass `[]` to disable filesystem settings (SDK isolation mode)"*). This is the actual leak: the option is currently omitted, and the SDK docs note that when omitted, *all* sources are loaded.
- **`mcpServers: {}`** — makes the empty server set explicit.

A summarizer needs no tools or MCP servers. This sits alongside the existing `persistSession: false` isolation (#83).

## Testing

- `npm run build` — clean (`tsc` + `esbuild`).
- `npm test` — 209 passed. One unrelated failure: a `beforeEach` hook timeout in `search-metadata-filters` from a cold embedding-model load exceeding the 10s hook limit (not touched by this change; later tests in that same file pass).
- Added 3 assertions to `test/summarizer-options.test.ts` covering `settingSources: []` and `mcpServers: {}` on both fresh and resumed option builds.

## Notes

- Rebuilt `dist/` for the changed module (`dist/summarizer.js`, `dist/summarizer.d.ts`), per `CLAUDE.md`.
- Left the unrelated `dist/version.*` / `dist/mcp-server.js` version-string drift (committed `1.4.1` vs `package.json` `1.4.2`) untouched to keep this PR focused on the fix.

Fixes #106
