### PR TITLE
fix: run Claude summarization tool-less so it can't hijack an active session

### DIFF
--- a/dist/summarizer.d.ts
+++ b/dist/summarizer.d.ts
@@ -51,6 +51,9 @@ export declare function formatConversationText(exchanges: ConversationExchange[]
  * ~/.claude/projects/ (#83). Without it, every summarization spawns a fake
  * session JSONL that pollutes the IDE session sidebar. The option is honored
  * by claude-agent-sdk >= 0.2.0.
+ *
+ * tools: [] disables every built-in tool so a resumed mid-task session can't
+ * keep EXECUTING the task instead of writing a <summary>.
  */
 export declare function buildSummarizerQueryOptions(args: {
     model: string;

--- a/dist/summarizer.js
+++ b/dist/summarizer.js
@@ -85,6 +85,9 @@ function extractSummary(text) {
  * ~/.claude/projects/ (#83). Without it, every summarization spawns a fake
  * session JSONL that pollutes the IDE session sidebar. The option is honored
  * by claude-agent-sdk >= 0.2.0.
+ *
+ * tools: [] disables every built-in tool so a resumed mid-task session can't
+ * keep EXECUTING the task instead of writing a <summary>.
  */
 export function buildSummarizerQueryOptions(args) {
     const { model, sessionId, cwd } = args;
@@ -94,6 +97,7 @@ export function buildSummarizerQueryOptions(args) {
         env: getApiEnv(),
         resume: sessionId,
         persistSession: false,
+        tools: [],
         // Resume looks up the session under ~/.claude/projects/<encoded-cwd>/, so pass the recorded cwd when it still exists on disk.
         ...(cwd && fs.existsSync(cwd) ? { cwd } : {}),
         // Don't override systemPrompt when resuming — the resumed session's prompt stays in effect.

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -104,6 +104,9 @@ function extractSummary(text: string): string {
  * ~/.claude/projects/ (#83). Without it, every summarization spawns a fake
  * session JSONL that pollutes the IDE session sidebar. The option is honored
  * by claude-agent-sdk >= 0.2.0.
+ *
+ * tools: [] disables every built-in tool so a resumed mid-task session can't
+ * keep EXECUTING the task instead of writing a <summary>.
  */
 export function buildSummarizerQueryOptions(args: {
   model: string;
@@ -117,6 +120,7 @@ export function buildSummarizerQueryOptions(args: {
     env: getApiEnv(),
     resume: sessionId,
     persistSession: false,
+    tools: [],
     // Resume looks up the session under ~/.claude/projects/<encoded-cwd>/, so pass the recorded cwd when it still exists on disk.
     ...(cwd && fs.existsSync(cwd) ? { cwd } : {}),
     // Don't override systemPrompt when resuming — the resumed session's prompt stays in effect.

--- a/test/show.test.ts
+++ b/test/show.test.ts
@@ -182,8 +182,8 @@ describe('show command - markdown formatting', () => {
     expect(markdown).toMatch(/\*\*Agent\*\*/);
     expect(markdown).toContain('Looking at your instructions');
 
-    // Should show timestamps
-    expect(markdown).toMatch(/9\/19\/2025|2025-09-19/);
+    const expectedTimestamp = new Date('2025-09-19T17:34:29.181Z').toLocaleString();
+    expect(markdown).toContain(expectedTimestamp);
   });
 
   it('should include tool calls in the output', () => {

--- a/test/summarizer-options.test.ts
+++ b/test/summarizer-options.test.ts
@@ -62,6 +62,18 @@ describe('buildSummarizerQueryOptions', () => {
     const opts = buildSummarizerQueryOptions({ model: 'haiku', sessionId: 'abc-123' });
     expect(opts.cwd).toBeUndefined();
   });
+
+  // tools: [] strips every built-in tool so a resumed mid-task session can't keep
+  // executing the task instead of summarizing.
+  it('disables all built-in tools via tools: [] so a resumed mid-task session cannot execute the task', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku', sessionId: 'abc-123' });
+    expect(opts.tools).toEqual([]);
+  });
+
+  it('applies the tool restriction on fresh (non-resume) sessions too, not only when resuming', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku' });
+    expect(opts.tools).toEqual([]);
+  });
 });
 
 describe('isResumeFailure', () => {


### PR DESCRIPTION
Background summarization could hijack an active Claude session and run commands in the user's working tree. To summarize a recent conversation the plugin **resumes that Claude session** and asks it for a `<summary>` — but it did so with full default tool access. When the resumed session was still **mid-task**, the model inherited the task's momentum *and* the ability to execute tools, so it kept *executing* the original task instead of summarizing.

Process fingerprint — a second `claude` parented under `sync-cli.js`, resuming a live session with full permissions:

```
…/claude-agent-sdk-linux-x64/claude --output-format stream-json --verbose \
  --input-format stream-json --model haiku --resume c7691203-9342-… \
  --permission-mode default --no-session-persistence
```

Observed during an active worktree session: the spawned agent committed a work-in-progress refactor on the user's branch with a model-generated message, along with various other tool uses. It recurred every sync cycle (~2–2.5h) and had to be killed each time.

## Root cause

`buildSummarizerQueryOptions()` in `src/summarizer.ts` set no tool, permission, or sandbox restriction, so the resumed Claude ran under `--permission-mode default` (full tool access). Summarization is text-only work, but nothing stopped the model from invoking `Bash`/`Edit`/`Write`/`Task`. This is asymmetric with the **Codex** summarizer path in the same file, which already forks read-only (`sandbox: 'read-only'`, `approvalPolicy: 'never'`). The `#87` reentrancy guard is orthogonal — it stops the recursive sync→summarize→sync cascade but does not restrict tool execution.

## Fix

Restrict the Claude summarization query to be tool-less — the Claude-side equivalent of the Codex `sandbox: 'read-only'` — via `tools: []` in `buildSummarizerQueryOptions()`. Per the Agent SDK `Options` docs, `tools` is the documented way to restrict which tools are available, and `[]` disables every built-in, so a resumed mid-task session has no tool to invoke and can only emit text.

(`allowedTools` is only an auto-approve list, not a restriction, and a `disallowedTools` denylist would be a strict subset of what `tools: []` already removes — so neither adds protection over `tools: []`.)

## Testing

New assertions in `test/summarizer-options.test.ts` pin the restriction so a future refactor can't silently drop it: `tools: []` verified on both the resume and fresh-session paths.

Also includes a fix to `test/show.test.ts`: its timestamp assertion used a hardcoded US/ISO regex and failed under non-US locales; it now computes the expected string via `toLocaleString()` the same way `show.ts` does, making it locale/timezone-independent.

## Verification

`npx vitest run test/summarizer-options.test.ts test/show.test.ts` → 44 passed. `dist/` rebuilt from `src/` and committed alongside it.

## Scope

This PR implements the must-have tool restriction. A separate, related issue — a session summarized mid-flight has its summary frozen at the partial state and never re-summarized as it grows — is tracked and fixed in a follow-up PR (#109) . The tool restriction alone defangs the runaway; the follow-up closes the frozen-partial gap.
