### PR TITLE
fix: summarize once idle, refresh on growth, and bound failed-summary retries

### DIFF
--- a/dist/indexer.js
+++ b/dist/indexer.js
@@ -5,7 +5,7 @@ import { parseConversation } from './parser.js';
 import { initEmbeddings, generateExchangeEmbedding } from './embeddings.js';
 import { summarizeConversation } from './summarizer.js';
 import { getArchiveDir, getExcludedProjects, getConversationSourceDirs, findJsonlFiles } from './paths.js';
-import { needsSummary, isQuiescent, writeSummary, writeErrorSentinelIfNew, } from './summary-sentinel.js';
+import { needsSummary, isQuiescent, writeSummary, recordSummaryFailure, } from './summary-sentinel.js';
 // Set max output tokens for Claude SDK (used by summarizer)
 process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '20000';
 // Increase max listeners for concurrent API calls
@@ -26,9 +26,10 @@ function sessionIdForSummary(exchanges) {
 }
 /**
  * Summarize one conversation once it has gone quiescent, writing the summary with
- * its coverage header. Preserves a prior summary on failure (an error sentinel is
- * written only for a first-time failure). Returns the summary, or null when the
- * conversation is skipped (not yet quiescent) or summarization fails.
+ * its coverage header. On failure, recordSummaryFailure preserves any prior
+ * summary and records the attempt (a first-time failure writes an error sentinel
+ * instead). Returns the summary, or null when the conversation is skipped (not yet
+ * quiescent) or summarization fails.
  */
 async function summarizeIfQuiescent(summaryPath, archivePath, exchanges, label) {
     if (!isQuiescent(exchanges, Date.now()))
@@ -40,7 +41,7 @@ async function summarizeIfQuiescent(summaryPath, archivePath, exchanges, label) 
         return summary;
     }
     catch (error) {
-        writeErrorSentinelIfNew(summaryPath, error);
+        recordSummaryFailure(summaryPath, error);
         console.log(`  ✗ ${label}: ${error}`);
         return null;
     }

--- a/dist/indexer.js
+++ b/dist/indexer.js
@@ -5,7 +5,7 @@ import { parseConversation } from './parser.js';
 import { initEmbeddings, generateExchangeEmbedding } from './embeddings.js';
 import { summarizeConversation } from './summarizer.js';
 import { getArchiveDir, getExcludedProjects, getConversationSourceDirs, findJsonlFiles } from './paths.js';
-import { formatErrorSentinel, shouldQueueForSummary } from './summary-sentinel.js';
+import { needsSummary, isQuiescent, writeSummary, writeErrorSentinelIfNew, } from './summary-sentinel.js';
 // Set max output tokens for Claude SDK (used by summarizer)
 process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '20000';
 // Increase max listeners for concurrent API calls
@@ -23,6 +23,27 @@ async function processBatch(items, processor, concurrency) {
 }
 function sessionIdForSummary(exchanges) {
     return exchanges.find(exchange => exchange.sessionId)?.sessionId;
+}
+/**
+ * Summarize one conversation once it has gone quiescent, writing the summary with
+ * its coverage header. Preserves a prior summary on failure (an error sentinel is
+ * written only for a first-time failure). Returns the summary, or null when the
+ * conversation is skipped (not yet quiescent) or summarization fails.
+ */
+async function summarizeIfQuiescent(summaryPath, archivePath, exchanges, label) {
+    if (!isQuiescent(exchanges, Date.now()))
+        return null;
+    try {
+        const summary = await summarizeConversation(exchanges, sessionIdForSummary(exchanges));
+        writeSummary(summaryPath, archivePath, exchanges, summary);
+        console.log(`  ✓ ${label}: ${summary.split(/\s+/).length} words`);
+        return summary;
+    }
+    catch (error) {
+        writeErrorSentinelIfNew(summaryPath, error);
+        console.log(`  ✗ ${label}: ${error}`);
+        return null;
+    }
 }
 export async function indexConversations(limitToProject, maxConversations, concurrency = 1, noSummaries = false) {
     console.log('Initializing database...');
@@ -89,27 +110,10 @@ export async function indexConversations(limitToProject, maxConversations, concu
             }
             // Batch summarize conversations in parallel (unless --no-summaries)
             if (!noSummaries) {
-                const needsSummary = toProcess.filter(c => shouldQueueForSummary(c.summaryPath));
-                if (needsSummary.length > 0) {
-                    console.log(`  Generating ${needsSummary.length} summaries (concurrency: ${concurrency})...`);
-                    await processBatch(needsSummary, async (conv) => {
-                        try {
-                            const summary = await summarizeConversation(conv.exchanges, sessionIdForSummary(conv.exchanges));
-                            fs.writeFileSync(conv.summaryPath, summary, 'utf-8');
-                            const wordCount = summary.split(/\s+/).length;
-                            console.log(`  ✓ ${conv.file}: ${wordCount} words`);
-                            return summary;
-                        }
-                        catch (error) {
-                            // Write an error sentinel so the failure is retryable on a later run (#96).
-                            try {
-                                fs.writeFileSync(conv.summaryPath, formatErrorSentinel(error), 'utf-8');
-                            }
-                            catch { }
-                            console.log(`  ✗ ${conv.file}: ${error}`);
-                            return null;
-                        }
-                    }, concurrency);
+                const toSummarize = toProcess.filter(c => needsSummary(c.summaryPath, c.archivePath));
+                if (toSummarize.length > 0) {
+                    console.log(`  Generating ${toSummarize.length} summaries (concurrency: ${concurrency})...`);
+                    await processBatch(toSummarize, conv => summarizeIfQuiescent(conv.summaryPath, conv.archivePath, conv.exchanges, conv.file), concurrency);
                 }
             }
             else {
@@ -173,21 +177,9 @@ export async function indexSession(sessionId, concurrency = 1, noSummaries = fal
                 if (exchanges.length > 0) {
                     // Generate summary (unless --no-summaries)
                     const summaryPath = archivePath.replace('.jsonl', '-summary.txt');
-                    if (!noSummaries && shouldQueueForSummary(summaryPath)) {
+                    if (!noSummaries && needsSummary(summaryPath, archivePath)) {
                         fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
-                        try {
-                            const summary = await summarizeConversation(exchanges, sessionIdForSummary(exchanges));
-                            fs.writeFileSync(summaryPath, summary, 'utf-8');
-                            console.log(`Summary: ${summary.split(/\s+/).length} words`);
-                        }
-                        catch (error) {
-                            // Write an error sentinel so the failure is retryable on a later run (#96).
-                            try {
-                                fs.writeFileSync(summaryPath, formatErrorSentinel(error), 'utf-8');
-                            }
-                            catch { }
-                            console.log(`Summary failed: ${error instanceof Error ? error.message : String(error)}`);
-                        }
+                        await summarizeIfQuiescent(summaryPath, archivePath, exchanges, file);
                     }
                     // Index
                     for (const exchange of exchanges) {
@@ -265,27 +257,10 @@ export async function indexUnprocessed(concurrency = 1, noSummaries = false) {
     console.log(`Found ${unprocessed.length} unprocessed conversations`);
     // Batch process summaries (unless --no-summaries)
     if (!noSummaries) {
-        const needsSummary = unprocessed.filter(c => shouldQueueForSummary(c.summaryPath));
-        if (needsSummary.length > 0) {
-            console.log(`Generating ${needsSummary.length} summaries (concurrency: ${concurrency})...\n`);
-            await processBatch(needsSummary, async (conv) => {
-                try {
-                    const summary = await summarizeConversation(conv.exchanges, sessionIdForSummary(conv.exchanges));
-                    fs.writeFileSync(conv.summaryPath, summary, 'utf-8');
-                    const wordCount = summary.split(/\s+/).length;
-                    console.log(`  ✓ ${conv.project}/${conv.file}: ${wordCount} words`);
-                    return summary;
-                }
-                catch (error) {
-                    // Write an error sentinel so the failure is retryable on a later run (#96).
-                    try {
-                        fs.writeFileSync(conv.summaryPath, formatErrorSentinel(error), 'utf-8');
-                    }
-                    catch { }
-                    console.log(`  ✗ ${conv.project}/${conv.file}: ${error}`);
-                    return null;
-                }
-            }, concurrency);
+        const toSummarize = unprocessed.filter(c => needsSummary(c.summaryPath, c.archivePath));
+        if (toSummarize.length > 0) {
+            console.log(`Generating ${toSummarize.length} summaries (concurrency: ${concurrency})...\n`);
+            await processBatch(toSummarize, conv => summarizeIfQuiescent(conv.summaryPath, conv.archivePath, conv.exchanges, `${conv.project}/${conv.file}`), concurrency);
         }
     }
     else {

--- a/dist/mcp-server.js
+++ b/dist/mcp-server.js
@@ -25002,6 +25002,23 @@ async function generateQueryEmbedding(query) {
 var ERROR_MARKER = "__ERRORED__";
 var ERROR_MARKER_PREFIX = `${ERROR_MARKER}
 `;
+var COVERAGE_PREFIX = "__COVERAGE__ ";
+function parseSummaryFile(content) {
+  if (!content.startsWith(COVERAGE_PREFIX)) {
+    return { coverage: null, body: content };
+  }
+  const newlineIndex = content.indexOf("\n");
+  const headerJson = content.slice(COVERAGE_PREFIX.length, newlineIndex === -1 ? void 0 : newlineIndex);
+  const body = newlineIndex === -1 ? "" : content.slice(newlineIndex + 1);
+  let coverage = null;
+  try {
+    const parsed = JSON.parse(headerJson);
+    if (parsed && typeof parsed.bytes === "number") coverage = parsed;
+  } catch {
+    coverage = null;
+  }
+  return { coverage, body };
+}
 function isErroredSentinel(content) {
   return content.startsWith(ERROR_MARKER_PREFIX);
 }
@@ -25165,7 +25182,7 @@ async function searchConversations(query, options = {}) {
     if (fs3.existsSync(summaryPath)) {
       const raw = fs3.readFileSync(summaryPath, "utf-8");
       if (!isErroredSentinel(raw)) {
-        summary = raw.trim();
+        summary = parseSummaryFile(raw).body.trim();
       }
     }
     const snippetText = exchange.userMessage.substring(0, 200).replace(/\s+/g, " ").trim();

--- a/dist/search.js
+++ b/dist/search.js
@@ -1,6 +1,6 @@
 import { initDatabase } from './db.js';
 import { initEmbeddings, generateQueryEmbedding } from './embeddings.js';
-import { isErroredSentinel } from './summary-sentinel.js';
+import { isErroredSentinel, parseSummaryFile } from './summary-sentinel.js';
 import fs from 'fs';
 import readline from 'readline';
 /**
@@ -182,7 +182,7 @@ export async function searchConversations(query, options = {}) {
         if (fs.existsSync(summaryPath)) {
             const raw = fs.readFileSync(summaryPath, 'utf-8');
             if (!isErroredSentinel(raw)) {
-                summary = raw.trim();
+                summary = parseSummaryFile(raw).body.trim();
             }
         }
         // Create snippet (first 200 chars, collapse newlines)

--- a/dist/summary-sentinel.d.ts
+++ b/dist/summary-sentinel.d.ts
@@ -1,3 +1,4 @@
+import type { ConversationExchange } from './types.js';
 /**
  * Sentinel file format for `<archive>/<project>/<session>-summary.txt`:
  *
@@ -13,18 +14,77 @@
  * could pin the head of the queue.
  */
 export declare const ERROR_MARKER = "__ERRORED__";
+export declare const COVERAGE_SCHEMA = 1;
+/**
+ * Machine-readable header recording how much of a transcript a summary
+ * reflects. Stored as the first line of a real summary file so a later
+ * sync can detect transcript growth and re-queue for re-summarization.
+ */
+export interface SummaryCoverage {
+    /** Archive JSONL byte size the summary reflects. Growth past this re-queues. */
+    bytes: number;
+    /** Timestamp of the last exchange the summary covered (diagnostic). */
+    lastExchange?: string;
+    schema: number;
+}
+/** Serialize a real summary with its coverage header as the first line. */
+export declare function formatSummaryFile(coverage: SummaryCoverage, body: string): string;
+/**
+ * Split a summary file into its coverage header (if present) and body.
+ * A header-less file is legacy: coverage is null and the whole content is body.
+ * A present-but-corrupt header line is stripped (never leaked into the body).
+ */
+export declare function parseSummaryFile(content: string): {
+    coverage: SummaryCoverage | null;
+    body: string;
+};
 export declare function formatErrorSentinel(error: unknown): string;
 export declare function isErroredSentinel(content: string): boolean;
 /**
  * True when the sentinel at `summaryPath` represents a real summary —
- * a non-empty file that is not an error marker. Empty zero-exchange
- * sentinels and error sentinels both return false. Use this for callers
- * that care about "is this conversation summarized and useful" (stats,
- * verify, search).
+ * a file with a non-empty summary body that is not an error marker. Empty
+ * zero-exchange sentinels, header-only files (empty body), and error sentinels
+ * all return false. Use this for callers that care about "is this conversation
+ * summarized and useful" (stats, verify, search).
  */
 export declare function hasRealSummary(summaryPath: string): boolean;
 /**
- * True when the conversation at `summaryPath` should be (re-)summarized:
- * no sentinel yet, or a stale error marker.
+ * Best-effort error sentinel, written only when no prior real summary exists so a
+ * re-summary failure never discards good content. Swallows its own write errors.
  */
-export declare function shouldQueueForSummary(summaryPath: string): boolean;
+export declare function writeErrorSentinelIfNew(summaryPath: string, error: unknown): void;
+/**
+ * True when the conversation at `summaryPath` should be (re-)summarized:
+ *  - no summary yet,
+ *  - a stale error marker, or
+ *  - a real summary whose covered byte size is below the current archive size
+ *    (the transcript has grown — append-only, so a size increase means new content).
+ * A legacy header-less summary returns false; callers must call
+ * ensureCoverageBaseline first so a baseline exists and future growth is detected.
+ */
+export declare function shouldQueueForSummary(summaryPath: string, currentArchiveBytes: number): boolean;
+/** Idle time a conversation must reach before it is (re)summarized.
+ *  Allows 0 (summarize immediately, e.g. in tests); rejects negative/garbage. */
+export declare function getQuiescenceMs(): number;
+/**
+ * True when the conversation has been idle for at least the quiescence window.
+ * Uses the last exchange's timestamp (file mtime is unreliable — the archive
+ * copy's mtime is reset every sync). A missing/unparseable timestamp is treated
+ * as quiescent so it never blocks summarization.
+ */
+export declare function isQuiescent(exchanges: ConversationExchange[], nowMs: number): boolean;
+/** Coverage metadata for the conversation currently archived at `archiveJsonlPath`. */
+export declare function buildCoverage(archiveJsonlPath: string, exchanges: ConversationExchange[]): SummaryCoverage;
+/** Write a real summary with its coverage header. The single summary-write path. */
+export declare function writeSummary(summaryPath: string, archiveJsonlPath: string, exchanges: ConversationExchange[], body: string): void;
+/**
+ * Stamp a legacy (header-less) real summary with current coverage — a header
+ * rewrite, NO LLM call — so existing summaries get a growth baseline without a
+ * mass re-summarization on upgrade. No-op for missing/empty/errored/already-stamped files.
+ */
+export declare function ensureCoverageBaseline(summaryPath: string, archiveBytes: number): void;
+/**
+ * True when a conversation needs a (re-)summary. Stamps a coverage baseline on a
+ * legacy header-less summary first, so future transcript growth stays detectable.
+ */
+export declare function needsSummary(summaryPath: string, archiveJsonlPath: string): boolean;

--- a/dist/summary-sentinel.d.ts
+++ b/dist/summary-sentinel.d.ts
@@ -16,6 +16,19 @@ import type { ConversationExchange } from './types.js';
 export declare const ERROR_MARKER = "__ERRORED__";
 export declare const COVERAGE_SCHEMA = 1;
 /**
+ * Attempt-counted failure state shared by both failure stores — the error
+ * sentinel (no good summary yet) and a preserved good summary's `resummary`
+ * field. Drives the unified backoff-and-give-up in shouldRetryAfterFailure: hold
+ * off until the retry floor elapses, then give up once the attempt budget is
+ * spent. Cleared when a summary finally succeeds.
+ */
+export interface FailureState {
+    /** Consecutive failed attempts since the last successful summary. */
+    attempts: number;
+    /** Epoch ms of the last failed attempt — gates the per-attempt retry floor. */
+    lastAttempt: number;
+}
+/**
  * Machine-readable header recording how much of a transcript a summary
  * reflects. Stored as the first line of a real summary file so a later
  * sync can detect transcript growth and re-queue for re-summarization.
@@ -26,6 +39,8 @@ export interface SummaryCoverage {
     /** Timestamp of the last exchange the summary covered (diagnostic). */
     lastExchange?: string;
     schema: number;
+    /** Present only after a re-summary has failed; absent on a healthy summary. */
+    resummary?: FailureState;
 }
 /** Serialize a real summary with its coverage header as the first line. */
 export declare function formatSummaryFile(coverage: SummaryCoverage, body: string): string;
@@ -38,8 +53,26 @@ export declare function parseSummaryFile(content: string): {
     coverage: SummaryCoverage | null;
     body: string;
 };
-export declare function formatErrorSentinel(error: unknown): string;
+/**
+ * Serialize an error sentinel: the marker, a JSON failure-state line (attempts +
+ * lastAttempt), then the human-readable error message. The failure state lets
+ * shouldQueueForSummary back off and give up identically to a re-summary failure.
+ */
+export declare function formatErrorSentinel(error: unknown, failure: FailureState): string;
 export declare function isErroredSentinel(content: string): boolean;
+/**
+ * Read the failure state from an error sentinel. Tolerates the legacy
+ * `__ERRORED__\n<ISO timestamp>\n<message>` form (no attempt count): the ISO
+ * time becomes lastAttempt and attempts starts at 0, so an upgraded sentinel
+ * keeps backing off correctly and recordSummaryFailure resumes counting.
+ */
+export declare function parseErrorSentinel(content: string): FailureState;
+/**
+ * Failed summary attempts to make before giving up — keeping whatever good
+ * summary exists (none, for a first-time failure). Bounds cost on a transcript
+ * that never summarizes. Configurable for operators/tests; falls back for garbage.
+ */
+export declare function getMaxSummaryAttempts(): number;
 /**
  * True when the sentinel at `summaryPath` represents a real summary —
  * a file with a non-empty summary body that is not an error marker. Empty
@@ -49,16 +82,24 @@ export declare function isErroredSentinel(content: string): boolean;
  */
 export declare function hasRealSummary(summaryPath: string): boolean;
 /**
- * Best-effort error sentinel, written only when no prior real summary exists so a
- * re-summary failure never discards good content. Swallows its own write errors.
+ * Record a summary failure, incrementing the attempt count. Best-effort —
+ * swallows its own IO errors. Both branches feed the same backoff/give-up policy
+ * (shouldRetryAfterFailure); a successful writeSummary later clears the state.
+ *  - No prior real summary: write an attempt-counted error sentinel (#96).
+ *  - Prior real summary exists: keep the good body but stamp the attempt + time
+ *    into its `resummary` header, so the last good summary survives the failure.
  */
-export declare function writeErrorSentinelIfNew(summaryPath: string, error: unknown): void;
+export declare function recordSummaryFailure(summaryPath: string, error: unknown): void;
 /**
  * True when the conversation at `summaryPath` should be (re-)summarized:
  *  - no summary yet,
  *  - a stale error marker, or
  *  - a real summary whose covered byte size is below the current archive size
  *    (the transcript has grown — append-only, so a size increase means new content).
+ * Both a stale error marker and a grown summary carrying failed-re-summary state
+ * are governed by shouldRetryAfterFailure — held back until the retry floor
+ * elapses, then abandoned once getMaxSummaryAttempts() is spent (keeping any good
+ * summary) so a never-summarizable transcript can't thrash.
  * A legacy header-less summary returns false; callers must call
  * ensureCoverageBaseline first so a baseline exists and future growth is detected.
  */

--- a/dist/summary-sentinel.js
+++ b/dist/summary-sentinel.js
@@ -19,6 +19,7 @@ const ERROR_MARKER_PREFIX = `${ERROR_MARKER}\n`;
 // milliseconds; convert at this single boundary so the two units never mix.
 const MS_PER_HOUR = 3600_000;
 const DEFAULT_ERROR_RETRY_HOURS = 1;
+const DEFAULT_SUMMARY_MAX_ATTEMPTS = 5;
 export const COVERAGE_SCHEMA = 1;
 const COVERAGE_PREFIX = '__COVERAGE__ ';
 /** Serialize a real summary with its coverage header as the first line. */
@@ -49,12 +50,35 @@ export function parseSummaryFile(content) {
     }
     return { coverage, body };
 }
-export function formatErrorSentinel(error) {
+/**
+ * Serialize an error sentinel: the marker, a JSON failure-state line (attempts +
+ * lastAttempt), then the human-readable error message. The failure state lets
+ * shouldQueueForSummary back off and give up identically to a re-summary failure.
+ */
+export function formatErrorSentinel(error, failure) {
     const message = error instanceof Error ? error.message : String(error);
-    return `${ERROR_MARKER}\n${new Date().toISOString()}\n${message}\n`;
+    return `${ERROR_MARKER}\n${JSON.stringify(failure)}\n${message}\n`;
 }
 export function isErroredSentinel(content) {
     return content.startsWith(ERROR_MARKER_PREFIX);
+}
+/**
+ * Read the failure state from an error sentinel. Tolerates the legacy
+ * `__ERRORED__\n<ISO timestamp>\n<message>` form (no attempt count): the ISO
+ * time becomes lastAttempt and attempts starts at 0, so an upgraded sentinel
+ * keeps backing off correctly and recordSummaryFailure resumes counting.
+ */
+export function parseErrorSentinel(content) {
+    const secondLine = content.split('\n', 2)[1] ?? '';
+    try {
+        const parsed = JSON.parse(secondLine);
+        if (parsed && typeof parsed.attempts === 'number' && typeof parsed.lastAttempt === 'number') {
+            return { attempts: parsed.attempts, lastAttempt: parsed.lastAttempt };
+        }
+    }
+    catch { /* legacy ISO-timestamp form */ }
+    const legacyTime = Date.parse(secondLine);
+    return { attempts: 0, lastAttempt: Number.isNaN(legacyTime) ? 0 : legacyTime };
 }
 /** Resolve an `_HOURS` env var to milliseconds, falling back to defaultHours for
  *  undefined/garbage. allowZero=false rejects 0 too (used for retry backoff). */
@@ -70,8 +94,32 @@ function resolveHoursEnvMs(name, defaultHours, allowZero) {
         return defaultMs;
     return hours * MS_PER_HOUR;
 }
-function getErrorRetryMs() {
+/** The retry floor: minimum idle time between failed summary attempts (a
+ *  first-time failure or a re-summary alike). Configurable in hours; default 1h. */
+function getRetryFloorMs() {
     return resolveHoursEnvMs('EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS', DEFAULT_ERROR_RETRY_HOURS, false);
+}
+/**
+ * Failed summary attempts to make before giving up — keeping whatever good
+ * summary exists (none, for a first-time failure). Bounds cost on a transcript
+ * that never summarizes. Configurable for operators/tests; falls back for garbage.
+ */
+export function getMaxSummaryAttempts() {
+    const raw = process.env.EPISODIC_MEMORY_SUMMARY_MAX_ATTEMPTS;
+    if (raw === undefined)
+        return DEFAULT_SUMMARY_MAX_ATTEMPTS;
+    const attempts = parseInt(raw, 10);
+    return Number.isInteger(attempts) && attempts >= 0 ? attempts : DEFAULT_SUMMARY_MAX_ATTEMPTS;
+}
+/**
+ * The single retry/give-up policy for any recorded summary failure: hold off
+ * until the retry floor has elapsed, then give up once the attempt budget is
+ * spent. Shared by the error-sentinel and re-summary paths so they stay in lockstep.
+ */
+function shouldRetryAfterFailure(failure) {
+    if (failure.attempts >= getMaxSummaryAttempts())
+        return false;
+    return Date.now() - failure.lastAttempt >= getRetryFloorMs();
 }
 /**
  * True when the sentinel at `summaryPath` represents a real summary —
@@ -96,14 +144,41 @@ export function hasRealSummary(summaryPath) {
         return false;
     return parseSummaryFile(content).body.trim().length > 0;
 }
-/**
- * Best-effort error sentinel, written only when no prior real summary exists so a
- * re-summary failure never discards good content. Swallows its own write errors.
- */
-export function writeErrorSentinelIfNew(summaryPath, error) {
+/** Attempts already recorded in an existing error sentinel, or 0 when there is
+ *  no sentinel (or it can't be read). Lets a repeat first-failure keep counting. */
+function readErrorAttempts(summaryPath) {
     try {
-        if (!hasRealSummary(summaryPath))
-            fs.writeFileSync(summaryPath, formatErrorSentinel(error), 'utf-8');
+        const content = fs.readFileSync(summaryPath, 'utf-8');
+        return isErroredSentinel(content) ? parseErrorSentinel(content).attempts : 0;
+    }
+    catch {
+        return 0;
+    }
+}
+/**
+ * Record a summary failure, incrementing the attempt count. Best-effort —
+ * swallows its own IO errors. Both branches feed the same backoff/give-up policy
+ * (shouldRetryAfterFailure); a successful writeSummary later clears the state.
+ *  - No prior real summary: write an attempt-counted error sentinel (#96).
+ *  - Prior real summary exists: keep the good body but stamp the attempt + time
+ *    into its `resummary` header, so the last good summary survives the failure.
+ */
+export function recordSummaryFailure(summaryPath, error) {
+    try {
+        const now = Date.now();
+        if (!hasRealSummary(summaryPath)) {
+            const attempts = readErrorAttempts(summaryPath) + 1;
+            fs.writeFileSync(summaryPath, formatErrorSentinel(error, { attempts, lastAttempt: now }), 'utf-8');
+            return;
+        }
+        const { coverage, body } = parseSummaryFile(fs.readFileSync(summaryPath, 'utf-8'));
+        // A legacy header-less good summary is never re-queued (shouldQueueForSummary
+        // returns false for null coverage), so leave it untouched rather than guessing a baseline.
+        if (coverage === null)
+            return;
+        const attempts = (coverage.resummary?.attempts ?? 0) + 1;
+        const updated = { ...coverage, resummary: { attempts, lastAttempt: now } };
+        fs.writeFileSync(summaryPath, formatSummaryFile(updated, body), 'utf-8');
     }
     catch { }
 }
@@ -113,6 +188,10 @@ export function writeErrorSentinelIfNew(summaryPath, error) {
  *  - a stale error marker, or
  *  - a real summary whose covered byte size is below the current archive size
  *    (the transcript has grown — append-only, so a size increase means new content).
+ * Both a stale error marker and a grown summary carrying failed-re-summary state
+ * are governed by shouldRetryAfterFailure — held back until the retry floor
+ * elapses, then abandoned once getMaxSummaryAttempts() is spent (keeping any good
+ * summary) so a never-summarizable transcript can't thrash.
  * A legacy header-less summary returns false; callers must call
  * ensureCoverageBaseline first so a baseline exists and future growth is detected.
  */
@@ -129,18 +208,16 @@ export function shouldQueueForSummary(summaryPath, currentArchiveBytes) {
     if (content.length === 0)
         return false;
     if (isErroredSentinel(content)) {
-        try {
-            const stat = fs.statSync(summaryPath);
-            return Date.now() - stat.mtimeMs >= getErrorRetryMs();
-        }
-        catch {
-            return false;
-        }
+        return shouldRetryAfterFailure(parseErrorSentinel(content));
     }
     const { coverage } = parseSummaryFile(content);
     if (coverage === null)
         return false; // legacy; caller must have stamped a baseline via ensureCoverageBaseline
-    return currentArchiveBytes > coverage.bytes;
+    if (currentArchiveBytes <= coverage.bytes)
+        return false; // transcript hasn't grown
+    // Transcript grew. A prior failed re-summary backs off / gives up under the
+    // same policy as a first-time failure; otherwise re-summarize the new content.
+    return coverage.resummary ? shouldRetryAfterFailure(coverage.resummary) : true;
 }
 const DEFAULT_QUIESCENCE_HOURS = 1;
 /** Idle time a conversation must reach before it is (re)summarized.

--- a/dist/summary-sentinel.js
+++ b/dist/summary-sentinel.js
@@ -15,7 +15,40 @@ import * as fs from 'fs';
  */
 export const ERROR_MARKER = '__ERRORED__';
 const ERROR_MARKER_PREFIX = `${ERROR_MARKER}\n`;
-const DEFAULT_RETRY_MS = 3600_000; // 1 hour
+// Time thresholds are configured in hours (the `_HOURS` env vars) and consumed in
+// milliseconds; convert at this single boundary so the two units never mix.
+const MS_PER_HOUR = 3600_000;
+const DEFAULT_ERROR_RETRY_HOURS = 1;
+export const COVERAGE_SCHEMA = 1;
+const COVERAGE_PREFIX = '__COVERAGE__ ';
+/** Serialize a real summary with its coverage header as the first line. */
+export function formatSummaryFile(coverage, body) {
+    return `${COVERAGE_PREFIX}${JSON.stringify(coverage)}\n${body}`;
+}
+/**
+ * Split a summary file into its coverage header (if present) and body.
+ * A header-less file is legacy: coverage is null and the whole content is body.
+ * A present-but-corrupt header line is stripped (never leaked into the body).
+ */
+export function parseSummaryFile(content) {
+    if (!content.startsWith(COVERAGE_PREFIX)) {
+        return { coverage: null, body: content };
+    }
+    const newlineIndex = content.indexOf('\n');
+    const headerJson = content.slice(COVERAGE_PREFIX.length, newlineIndex === -1 ? undefined : newlineIndex);
+    const body = newlineIndex === -1 ? '' : content.slice(newlineIndex + 1);
+    let coverage = null;
+    try {
+        const parsed = JSON.parse(headerJson);
+        // Validate only `bytes` (the growth signal); schema-version handling is deferred to the consumer.
+        if (parsed && typeof parsed.bytes === 'number')
+            coverage = parsed;
+    }
+    catch {
+        coverage = null;
+    }
+    return { coverage, body };
+}
 export function formatErrorSentinel(error) {
     const message = error instanceof Error ? error.message : String(error);
     return `${ERROR_MARKER}\n${new Date().toISOString()}\n${message}\n`;
@@ -23,19 +56,29 @@ export function formatErrorSentinel(error) {
 export function isErroredSentinel(content) {
     return content.startsWith(ERROR_MARKER_PREFIX);
 }
-function getErrorRetryMs() {
-    const raw = process.env.EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS;
-    if (!raw)
-        return DEFAULT_RETRY_MS;
+/** Resolve an `_HOURS` env var to milliseconds, falling back to defaultHours for
+ *  undefined/garbage. allowZero=false rejects 0 too (used for retry backoff). */
+function resolveHoursEnvMs(name, defaultHours, allowZero) {
+    const defaultMs = defaultHours * MS_PER_HOUR;
+    const raw = process.env[name];
+    if (raw === undefined)
+        return defaultMs;
     const hours = parseFloat(raw);
-    return Number.isFinite(hours) && hours > 0 ? hours * 3600_000 : DEFAULT_RETRY_MS;
+    if (!Number.isFinite(hours))
+        return defaultMs;
+    if (allowZero ? hours < 0 : hours <= 0)
+        return defaultMs;
+    return hours * MS_PER_HOUR;
+}
+function getErrorRetryMs() {
+    return resolveHoursEnvMs('EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS', DEFAULT_ERROR_RETRY_HOURS, false);
 }
 /**
  * True when the sentinel at `summaryPath` represents a real summary —
- * a non-empty file that is not an error marker. Empty zero-exchange
- * sentinels and error sentinels both return false. Use this for callers
- * that care about "is this conversation summarized and useful" (stats,
- * verify, search).
+ * a file with a non-empty summary body that is not an error marker. Empty
+ * zero-exchange sentinels, header-only files (empty body), and error sentinels
+ * all return false. Use this for callers that care about "is this conversation
+ * summarized and useful" (stats, verify, search).
  */
 export function hasRealSummary(summaryPath) {
     if (!fs.existsSync(summaryPath))
@@ -51,13 +94,29 @@ export function hasRealSummary(summaryPath) {
         return false;
     if (isErroredSentinel(content))
         return false;
-    return true;
+    return parseSummaryFile(content).body.trim().length > 0;
+}
+/**
+ * Best-effort error sentinel, written only when no prior real summary exists so a
+ * re-summary failure never discards good content. Swallows its own write errors.
+ */
+export function writeErrorSentinelIfNew(summaryPath, error) {
+    try {
+        if (!hasRealSummary(summaryPath))
+            fs.writeFileSync(summaryPath, formatErrorSentinel(error), 'utf-8');
+    }
+    catch { }
 }
 /**
  * True when the conversation at `summaryPath` should be (re-)summarized:
- * no sentinel yet, or a stale error marker.
+ *  - no summary yet,
+ *  - a stale error marker, or
+ *  - a real summary whose covered byte size is below the current archive size
+ *    (the transcript has grown — append-only, so a size increase means new content).
+ * A legacy header-less summary returns false; callers must call
+ * ensureCoverageBaseline first so a baseline exists and future growth is detected.
  */
-export function shouldQueueForSummary(summaryPath) {
+export function shouldQueueForSummary(summaryPath, currentArchiveBytes) {
     if (!fs.existsSync(summaryPath))
         return true;
     let content;
@@ -67,13 +126,83 @@ export function shouldQueueForSummary(summaryPath) {
     catch {
         return false;
     }
-    if (!isErroredSentinel(content))
+    if (content.length === 0)
         return false;
+    if (isErroredSentinel(content)) {
+        try {
+            const stat = fs.statSync(summaryPath);
+            return Date.now() - stat.mtimeMs >= getErrorRetryMs();
+        }
+        catch {
+            return false;
+        }
+    }
+    const { coverage } = parseSummaryFile(content);
+    if (coverage === null)
+        return false; // legacy; caller must have stamped a baseline via ensureCoverageBaseline
+    return currentArchiveBytes > coverage.bytes;
+}
+const DEFAULT_QUIESCENCE_HOURS = 1;
+/** Idle time a conversation must reach before it is (re)summarized.
+ *  Allows 0 (summarize immediately, e.g. in tests); rejects negative/garbage. */
+export function getQuiescenceMs() {
+    return resolveHoursEnvMs('EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS', DEFAULT_QUIESCENCE_HOURS, true);
+}
+/**
+ * True when the conversation has been idle for at least the quiescence window.
+ * Uses the last exchange's timestamp (file mtime is unreliable — the archive
+ * copy's mtime is reset every sync). A missing/unparseable timestamp is treated
+ * as quiescent so it never blocks summarization.
+ */
+export function isQuiescent(exchanges, nowMs) {
+    const last = exchanges[exchanges.length - 1];
+    if (!last?.timestamp)
+        return true;
+    const ts = Date.parse(last.timestamp);
+    if (Number.isNaN(ts))
+        return true;
+    return nowMs - ts >= getQuiescenceMs();
+}
+/** Coverage metadata for the conversation currently archived at `archiveJsonlPath`. */
+export function buildCoverage(archiveJsonlPath, exchanges) {
+    return {
+        bytes: fs.statSync(archiveJsonlPath).size,
+        lastExchange: exchanges[exchanges.length - 1]?.timestamp,
+        schema: COVERAGE_SCHEMA,
+    };
+}
+/** Write a real summary with its coverage header. The single summary-write path. */
+export function writeSummary(summaryPath, archiveJsonlPath, exchanges, body) {
+    fs.writeFileSync(summaryPath, formatSummaryFile(buildCoverage(archiveJsonlPath, exchanges), body), 'utf-8');
+}
+/**
+ * Stamp a legacy (header-less) real summary with current coverage — a header
+ * rewrite, NO LLM call — so existing summaries get a growth baseline without a
+ * mass re-summarization on upgrade. No-op for missing/empty/errored/already-stamped files.
+ */
+export function ensureCoverageBaseline(summaryPath, archiveBytes) {
+    if (!fs.existsSync(summaryPath))
+        return;
+    let content;
     try {
-        const stat = fs.statSync(summaryPath);
-        return Date.now() - stat.mtimeMs >= getErrorRetryMs();
+        content = fs.readFileSync(summaryPath, 'utf-8');
     }
     catch {
-        return false;
+        return;
     }
+    if (content.length === 0 || isErroredSentinel(content))
+        return;
+    const { coverage, body } = parseSummaryFile(content);
+    if (coverage !== null)
+        return;
+    fs.writeFileSync(summaryPath, formatSummaryFile({ bytes: archiveBytes, schema: COVERAGE_SCHEMA }, body), 'utf-8');
+}
+/**
+ * True when a conversation needs a (re-)summary. Stamps a coverage baseline on a
+ * legacy header-less summary first, so future transcript growth stays detectable.
+ */
+export function needsSummary(summaryPath, archiveJsonlPath) {
+    const archiveBytes = fs.statSync(archiveJsonlPath).size;
+    ensureCoverageBaseline(summaryPath, archiveBytes);
+    return shouldQueueForSummary(summaryPath, archiveBytes);
 }

--- a/dist/sync.d.ts
+++ b/dist/sync.d.ts
@@ -14,4 +14,13 @@ export interface SyncOptions {
     summaryLimit?: number;
 }
 export declare function extractSessionIdFromPath(filePath: string): string | null;
+/**
+ * Order a summary queue so never-summarized conversations come before re-summary
+ * retries (a conversation that already has a good summary). A backlog of growing
+ * or failing re-summaries must not starve fresh work out of the per-run
+ * summaryLimit — the #91 head-of-queue failure mode. Stable within each group.
+ */
+export declare function orderFreshBeforeRetry<T extends {
+    path: string;
+}>(files: T[]): T[];
 export declare function syncConversations(sourceDir: string, destDir: string, options?: SyncOptions): Promise<SyncResult>;

--- a/dist/sync.js
+++ b/dist/sync.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { SUMMARIZER_CONTEXT_MARKER } from './constants.js';
 import { getExcludedProjects, findJsonlFiles } from './paths.js';
-import { formatErrorSentinel, shouldQueueForSummary } from './summary-sentinel.js';
+import { needsSummary, isQuiescent, writeSummary, writeErrorSentinelIfNew, } from './summary-sentinel.js';
 const EXCLUSION_MARKERS = [
     '<INSTRUCTIONS-TO-EPISODIC-MEMORY>DO NOT INDEX THIS CHAT</INSTRUCTIONS-TO-EPISODIC-MEMORY>',
     'Only use NO_INSIGHTS_FOUND',
@@ -90,11 +90,9 @@ export async function syncConversations(sourceDir, destDir, options = {}) {
                     result.skipped++;
                 }
                 // Check if this file needs a summary (whether newly copied or existing).
-                // shouldQueueForSummary skips files that already have a real summary or
-                // an empty zero-exchange sentinel, and retries stale error sentinels (#96).
                 if (!options.skipSummaries) {
                     const summaryPath = destFile.replace('.jsonl', '-summary.txt');
-                    if (shouldQueueForSummary(summaryPath) && !shouldSkipConversation(destFile)) {
+                    if (needsSummary(summaryPath, destFile) && !shouldSkipConversation(destFile)) {
                         const sessionId = extractSessionIdFromPath(destFile);
                         if (sessionId) {
                             filesToSummarize.push({ path: destFile, sessionId });
@@ -153,35 +151,28 @@ export async function syncConversations(sourceDir, destDir, options = {}) {
             console.log(`  (${remaining} more need summaries - will process on next sync)`);
         }
         for (const { path: filePath, sessionId } of toSummarize) {
+            const summaryPath = filePath.replace('.jsonl', '-summary.txt');
             try {
                 const project = path.basename(path.dirname(filePath));
                 const exchanges = await parseConversation(filePath, project, filePath);
                 if (exchanges.length === 0) {
-                    // Skip empty conversations — write an empty -summary.txt sentinel so they aren't re-queued forever
-                    const summaryPath = filePath.replace('.jsonl', '-summary.txt');
-                    fs.writeFileSync(summaryPath, '', 'utf-8');
+                    fs.writeFileSync(summaryPath, '', 'utf-8'); // empty zero-exchange sentinel
                     continue;
                 }
+                // Only summarize once the conversation is quiescent, so we never freeze a
+                // mid-session snapshot. A non-quiescent file is left as-is and re-queued next sync.
+                if (!isQuiescent(exchanges, Date.now()))
+                    continue;
                 console.log(`  Summarizing ${path.basename(filePath)} (${exchanges.length} exchanges)...`);
                 const summary = await summarizeConversation(exchanges, sessionId);
-                const summaryPath = filePath.replace('.jsonl', '-summary.txt');
-                fs.writeFileSync(summaryPath, summary, 'utf-8');
+                writeSummary(summaryPath, filePath, exchanges, summary);
                 result.summarized++;
             }
             catch (error) {
-                // Write a structured error sentinel (#96): distinct from the empty
-                // zero-exchange sentinel so a stale failure can self-heal on the next
-                // sync run past the retry threshold. The marker also keeps the error
-                // text on disk for post-hoc diagnosis. Best-effort — if the sentinel
-                // write itself fails, fall through and surface the original error.
-                try {
-                    const summaryPath = filePath.replace('.jsonl', '-summary.txt');
-                    fs.writeFileSync(summaryPath, formatErrorSentinel(error), 'utf-8');
-                }
-                catch { }
+                writeErrorSentinelIfNew(summaryPath, error);
                 result.errors.push({
                     file: filePath,
-                    error: `Summary generation failed: ${error instanceof Error ? error.message : String(error)}`
+                    error: `Summary generation failed: ${error instanceof Error ? error.message : String(error)}`,
                 });
             }
         }

--- a/dist/sync.js
+++ b/dist/sync.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { SUMMARIZER_CONTEXT_MARKER } from './constants.js';
 import { getExcludedProjects, findJsonlFiles } from './paths.js';
-import { needsSummary, isQuiescent, writeSummary, writeErrorSentinelIfNew, } from './summary-sentinel.js';
+import { needsSummary, isQuiescent, writeSummary, recordSummaryFailure, hasRealSummary, } from './summary-sentinel.js';
 const EXCLUSION_MARKERS = [
     '<INSTRUCTIONS-TO-EPISODIC-MEMORY>DO NOT INDEX THIS CHAT</INSTRUCTIONS-TO-EPISODIC-MEMORY>',
     'Only use NO_INSIGHTS_FOUND',
@@ -47,6 +47,21 @@ export function extractSessionIdFromPath(filePath) {
         return matches[matches.length - 1];
     }
     return null;
+}
+/**
+ * Order a summary queue so never-summarized conversations come before re-summary
+ * retries (a conversation that already has a good summary). A backlog of growing
+ * or failing re-summaries must not starve fresh work out of the per-run
+ * summaryLimit — the #91 head-of-queue failure mode. Stable within each group.
+ */
+export function orderFreshBeforeRetry(files) {
+    const fresh = [];
+    const retries = [];
+    for (const file of files) {
+        const summaryPath = file.path.replace('.jsonl', '-summary.txt');
+        (hasRealSummary(summaryPath) ? retries : fresh).push(file);
+    }
+    return [...fresh, ...retries];
 }
 export async function syncConversations(sourceDir, destDir, options = {}) {
     const result = {
@@ -144,7 +159,7 @@ export async function syncConversations(sourceDir, destDir, options = {}) {
         const { parseConversation } = await import('./parser.js');
         const { summarizeConversation } = await import('./summarizer.js');
         const summaryLimit = options.summaryLimit ?? 10;
-        const toSummarize = filesToSummarize.slice(0, summaryLimit);
+        const toSummarize = orderFreshBeforeRetry(filesToSummarize).slice(0, summaryLimit);
         const remaining = filesToSummarize.length - toSummarize.length;
         console.log(`Generating summaries for ${toSummarize.length} conversation(s)...`);
         if (remaining > 0) {
@@ -169,7 +184,7 @@ export async function syncConversations(sourceDir, destDir, options = {}) {
                 result.summarized++;
             }
             catch (error) {
-                writeErrorSentinelIfNew(summaryPath, error);
+                recordSummaryFailure(summaryPath, error);
                 result.errors.push({
                     file: filePath,
                     error: `Summary generation failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/dist/verify.js
+++ b/dist/verify.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { parseConversation } from './parser.js';
 import { initDatabase, getAllExchanges, getFileLastIndexed } from './db.js';
 import { getArchiveDir, getExcludedProjects, findJsonlFiles } from './paths.js';
-import { isErroredSentinel } from './summary-sentinel.js';
+import { isErroredSentinel, writeSummary } from './summary-sentinel.js';
 export async function verifyIndex() {
     const result = {
         missing: [],
@@ -126,7 +126,7 @@ export async function repairIndex(issues) {
             // Generate/update summary
             const summaryPath = conversationPath.replace('.jsonl', '-summary.txt');
             const summary = await summarizeConversation(exchanges);
-            fs.writeFileSync(summaryPath, summary, 'utf-8');
+            writeSummary(summaryPath, conversationPath, exchanges, summary);
             console.log(`  Created summary: ${summary.split(/\s+/).length} words`);
             // Index exchanges
             for (const exchange of exchanges) {

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -7,7 +7,9 @@ import { initEmbeddings, generateExchangeEmbedding } from './embeddings.js';
 import { summarizeConversation } from './summarizer.js';
 import { ConversationExchange } from './types.js';
 import { getArchiveDir, getExcludedProjects, getConversationSourceDirs, findJsonlFiles } from './paths.js';
-import { formatErrorSentinel, shouldQueueForSummary } from './summary-sentinel.js';
+import {
+  needsSummary, isQuiescent, writeSummary, writeErrorSentinelIfNew,
+} from './summary-sentinel.js';
 
 // Set max output tokens for Claude SDK (used by summarizer)
 process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '20000';
@@ -35,6 +37,31 @@ async function processBatch<T, R>(
 
 function sessionIdForSummary(exchanges: ConversationExchange[]): string | undefined {
   return exchanges.find(exchange => exchange.sessionId)?.sessionId;
+}
+
+/**
+ * Summarize one conversation once it has gone quiescent, writing the summary with
+ * its coverage header. Preserves a prior summary on failure (an error sentinel is
+ * written only for a first-time failure). Returns the summary, or null when the
+ * conversation is skipped (not yet quiescent) or summarization fails.
+ */
+async function summarizeIfQuiescent(
+  summaryPath: string,
+  archivePath: string,
+  exchanges: ConversationExchange[],
+  label: string,
+): Promise<string | null> {
+  if (!isQuiescent(exchanges, Date.now())) return null;
+  try {
+    const summary = await summarizeConversation(exchanges, sessionIdForSummary(exchanges));
+    writeSummary(summaryPath, archivePath, exchanges, summary);
+    console.log(`  ✓ ${label}: ${summary.split(/\s+/).length} words`);
+    return summary;
+  } catch (error) {
+    writeErrorSentinelIfNew(summaryPath, error);
+    console.log(`  ✗ ${label}: ${error}`);
+    return null;
+  }
 }
 
 export async function indexConversations(
@@ -132,25 +159,15 @@ export async function indexConversations(
 
     // Batch summarize conversations in parallel (unless --no-summaries)
     if (!noSummaries) {
-      const needsSummary = toProcess.filter(c => shouldQueueForSummary(c.summaryPath));
+      const toSummarize = toProcess.filter(c => needsSummary(c.summaryPath, c.archivePath));
 
-      if (needsSummary.length > 0) {
-        console.log(`  Generating ${needsSummary.length} summaries (concurrency: ${concurrency})...`);
-
-        await processBatch(needsSummary, async (conv) => {
-          try {
-            const summary = await summarizeConversation(conv.exchanges, sessionIdForSummary(conv.exchanges));
-            fs.writeFileSync(conv.summaryPath, summary, 'utf-8');
-            const wordCount = summary.split(/\s+/).length;
-            console.log(`  ✓ ${conv.file}: ${wordCount} words`);
-            return summary;
-          } catch (error) {
-            // Write an error sentinel so the failure is retryable on a later run (#96).
-            try { fs.writeFileSync(conv.summaryPath, formatErrorSentinel(error), 'utf-8'); } catch {}
-            console.log(`  ✗ ${conv.file}: ${error}`);
-            return null;
-          }
-        }, concurrency);
+      if (toSummarize.length > 0) {
+        console.log(`  Generating ${toSummarize.length} summaries (concurrency: ${concurrency})...`);
+        await processBatch(
+          toSummarize,
+          conv => summarizeIfQuiescent(conv.summaryPath, conv.archivePath, conv.exchanges, conv.file),
+          concurrency,
+        );
       }
     } else {
       console.log(`  Skipping ${toProcess.length} summaries (--no-summaries mode)`);
@@ -233,17 +250,9 @@ export async function indexSession(sessionId: string, concurrency: number = 1, n
       if (exchanges.length > 0) {
         // Generate summary (unless --no-summaries)
         const summaryPath = archivePath.replace('.jsonl', '-summary.txt');
-        if (!noSummaries && shouldQueueForSummary(summaryPath)) {
+        if (!noSummaries && needsSummary(summaryPath, archivePath)) {
           fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
-          try {
-            const summary = await summarizeConversation(exchanges, sessionIdForSummary(exchanges));
-            fs.writeFileSync(summaryPath, summary, 'utf-8');
-            console.log(`Summary: ${summary.split(/\s+/).length} words`);
-          } catch (error) {
-            // Write an error sentinel so the failure is retryable on a later run (#96).
-            try { fs.writeFileSync(summaryPath, formatErrorSentinel(error), 'utf-8'); } catch {}
-            console.log(`Summary failed: ${error instanceof Error ? error.message : String(error)}`);
-          }
+          await summarizeIfQuiescent(summaryPath, archivePath, exchanges, file);
         }
 
         // Index
@@ -351,24 +360,14 @@ export async function indexUnprocessed(concurrency: number = 1, noSummaries: boo
 
   // Batch process summaries (unless --no-summaries)
   if (!noSummaries) {
-    const needsSummary = unprocessed.filter(c => shouldQueueForSummary(c.summaryPath));
-    if (needsSummary.length > 0) {
-      console.log(`Generating ${needsSummary.length} summaries (concurrency: ${concurrency})...\n`);
-
-      await processBatch(needsSummary, async (conv) => {
-        try {
-          const summary = await summarizeConversation(conv.exchanges, sessionIdForSummary(conv.exchanges));
-          fs.writeFileSync(conv.summaryPath, summary, 'utf-8');
-          const wordCount = summary.split(/\s+/).length;
-          console.log(`  ✓ ${conv.project}/${conv.file}: ${wordCount} words`);
-          return summary;
-        } catch (error) {
-          // Write an error sentinel so the failure is retryable on a later run (#96).
-          try { fs.writeFileSync(conv.summaryPath, formatErrorSentinel(error), 'utf-8'); } catch {}
-          console.log(`  ✗ ${conv.project}/${conv.file}: ${error}`);
-          return null;
-        }
-      }, concurrency);
+    const toSummarize = unprocessed.filter(c => needsSummary(c.summaryPath, c.archivePath));
+    if (toSummarize.length > 0) {
+      console.log(`Generating ${toSummarize.length} summaries (concurrency: ${concurrency})...\n`);
+      await processBatch(
+        toSummarize,
+        conv => summarizeIfQuiescent(conv.summaryPath, conv.archivePath, conv.exchanges, `${conv.project}/${conv.file}`),
+        concurrency,
+      );
     }
   } else {
     console.log(`Skipping summaries for ${unprocessed.length} conversations (--no-summaries mode)\n`);

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -8,7 +8,7 @@ import { summarizeConversation } from './summarizer.js';
 import { ConversationExchange } from './types.js';
 import { getArchiveDir, getExcludedProjects, getConversationSourceDirs, findJsonlFiles } from './paths.js';
 import {
-  needsSummary, isQuiescent, writeSummary, writeErrorSentinelIfNew,
+  needsSummary, isQuiescent, writeSummary, recordSummaryFailure,
 } from './summary-sentinel.js';
 
 // Set max output tokens for Claude SDK (used by summarizer)
@@ -41,9 +41,10 @@ function sessionIdForSummary(exchanges: ConversationExchange[]): string | undefi
 
 /**
  * Summarize one conversation once it has gone quiescent, writing the summary with
- * its coverage header. Preserves a prior summary on failure (an error sentinel is
- * written only for a first-time failure). Returns the summary, or null when the
- * conversation is skipped (not yet quiescent) or summarization fails.
+ * its coverage header. On failure, recordSummaryFailure preserves any prior
+ * summary and records the attempt (a first-time failure writes an error sentinel
+ * instead). Returns the summary, or null when the conversation is skipped (not yet
+ * quiescent) or summarization fails.
  */
 async function summarizeIfQuiescent(
   summaryPath: string,
@@ -58,7 +59,7 @@ async function summarizeIfQuiescent(
     console.log(`  ✓ ${label}: ${summary.split(/\s+/).length} words`);
     return summary;
   } catch (error) {
-    writeErrorSentinelIfNew(summaryPath, error);
+    recordSummaryFailure(summaryPath, error);
     console.log(`  ✗ ${label}: ${error}`);
     return null;
   }

--- a/src/search.ts
+++ b/src/search.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import { initDatabase } from './db.js';
 import { initEmbeddings, generateQueryEmbedding } from './embeddings.js';
 import { SearchResult, ConversationExchange, MultiConceptResult } from './types.js';
-import { isErroredSentinel } from './summary-sentinel.js';
+import { isErroredSentinel, parseSummaryFile } from './summary-sentinel.js';
 import fs from 'fs';
 import readline from 'readline';
 
@@ -218,7 +218,7 @@ export async function searchConversations(
     if (fs.existsSync(summaryPath)) {
       const raw = fs.readFileSync(summaryPath, 'utf-8');
       if (!isErroredSentinel(raw)) {
-        summary = raw.trim();
+        summary = parseSummaryFile(raw).body.trim();
       }
     }
 

--- a/src/summary-sentinel.ts
+++ b/src/summary-sentinel.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import type { ConversationExchange } from './types.js';
 
 /**
  * Sentinel file format for `<archive>/<project>/<session>-summary.txt`:
@@ -16,7 +17,55 @@ import * as fs from 'fs';
  */
 export const ERROR_MARKER = '__ERRORED__';
 const ERROR_MARKER_PREFIX = `${ERROR_MARKER}\n`;
-const DEFAULT_RETRY_MS = 3600_000; // 1 hour
+
+// Time thresholds are configured in hours (the `_HOURS` env vars) and consumed in
+// milliseconds; convert at this single boundary so the two units never mix.
+const MS_PER_HOUR = 3600_000;
+const DEFAULT_ERROR_RETRY_HOURS = 1;
+
+export const COVERAGE_SCHEMA = 1;
+const COVERAGE_PREFIX = '__COVERAGE__ ';
+
+/**
+ * Machine-readable header recording how much of a transcript a summary
+ * reflects. Stored as the first line of a real summary file so a later
+ * sync can detect transcript growth and re-queue for re-summarization.
+ */
+export interface SummaryCoverage {
+  /** Archive JSONL byte size the summary reflects. Growth past this re-queues. */
+  bytes: number;
+  /** Timestamp of the last exchange the summary covered (diagnostic). */
+  lastExchange?: string;
+  schema: number;
+}
+
+/** Serialize a real summary with its coverage header as the first line. */
+export function formatSummaryFile(coverage: SummaryCoverage, body: string): string {
+  return `${COVERAGE_PREFIX}${JSON.stringify(coverage)}\n${body}`;
+}
+
+/**
+ * Split a summary file into its coverage header (if present) and body.
+ * A header-less file is legacy: coverage is null and the whole content is body.
+ * A present-but-corrupt header line is stripped (never leaked into the body).
+ */
+export function parseSummaryFile(content: string): { coverage: SummaryCoverage | null; body: string } {
+  if (!content.startsWith(COVERAGE_PREFIX)) {
+    return { coverage: null, body: content };
+  }
+  const newlineIndex = content.indexOf('\n');
+  const headerJson = content.slice(COVERAGE_PREFIX.length, newlineIndex === -1 ? undefined : newlineIndex);
+  const body = newlineIndex === -1 ? '' : content.slice(newlineIndex + 1);
+  let coverage: SummaryCoverage | null = null;
+  try {
+    const parsed = JSON.parse(headerJson);
+    // Validate only `bytes` (the growth signal); schema-version handling is deferred to the consumer.
+    if (parsed && typeof parsed.bytes === 'number') coverage = parsed as SummaryCoverage;
+  } catch {
+    coverage = null;
+  }
+  return { coverage, body };
+}
 
 export function formatErrorSentinel(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
@@ -27,19 +76,28 @@ export function isErroredSentinel(content: string): boolean {
   return content.startsWith(ERROR_MARKER_PREFIX);
 }
 
-function getErrorRetryMs(): number {
-  const raw = process.env.EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS;
-  if (!raw) return DEFAULT_RETRY_MS;
+/** Resolve an `_HOURS` env var to milliseconds, falling back to defaultHours for
+ *  undefined/garbage. allowZero=false rejects 0 too (used for retry backoff). */
+function resolveHoursEnvMs(name: string, defaultHours: number, allowZero: boolean): number {
+  const defaultMs = defaultHours * MS_PER_HOUR;
+  const raw = process.env[name];
+  if (raw === undefined) return defaultMs;
   const hours = parseFloat(raw);
-  return Number.isFinite(hours) && hours > 0 ? hours * 3600_000 : DEFAULT_RETRY_MS;
+  if (!Number.isFinite(hours)) return defaultMs;
+  if (allowZero ? hours < 0 : hours <= 0) return defaultMs;
+  return hours * MS_PER_HOUR;
+}
+
+function getErrorRetryMs(): number {
+  return resolveHoursEnvMs('EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS', DEFAULT_ERROR_RETRY_HOURS, false);
 }
 
 /**
  * True when the sentinel at `summaryPath` represents a real summary —
- * a non-empty file that is not an error marker. Empty zero-exchange
- * sentinels and error sentinels both return false. Use this for callers
- * that care about "is this conversation summarized and useful" (stats,
- * verify, search).
+ * a file with a non-empty summary body that is not an error marker. Empty
+ * zero-exchange sentinels, header-only files (empty body), and error sentinels
+ * all return false. Use this for callers that care about "is this conversation
+ * summarized and useful" (stats, verify, search).
  */
 export function hasRealSummary(summaryPath: string): boolean {
   if (!fs.existsSync(summaryPath)) return false;
@@ -51,14 +109,29 @@ export function hasRealSummary(summaryPath: string): boolean {
   }
   if (content.length === 0) return false;
   if (isErroredSentinel(content)) return false;
-  return true;
+  return parseSummaryFile(content).body.trim().length > 0;
+}
+
+/**
+ * Best-effort error sentinel, written only when no prior real summary exists so a
+ * re-summary failure never discards good content. Swallows its own write errors.
+ */
+export function writeErrorSentinelIfNew(summaryPath: string, error: unknown): void {
+  try {
+    if (!hasRealSummary(summaryPath)) fs.writeFileSync(summaryPath, formatErrorSentinel(error), 'utf-8');
+  } catch {}
 }
 
 /**
  * True when the conversation at `summaryPath` should be (re-)summarized:
- * no sentinel yet, or a stale error marker.
+ *  - no summary yet,
+ *  - a stale error marker, or
+ *  - a real summary whose covered byte size is below the current archive size
+ *    (the transcript has grown — append-only, so a size increase means new content).
+ * A legacy header-less summary returns false; callers must call
+ * ensureCoverageBaseline first so a baseline exists and future growth is detected.
  */
-export function shouldQueueForSummary(summaryPath: string): boolean {
+export function shouldQueueForSummary(summaryPath: string, currentArchiveBytes: number): boolean {
   if (!fs.existsSync(summaryPath)) return true;
   let content: string;
   try {
@@ -66,11 +139,82 @@ export function shouldQueueForSummary(summaryPath: string): boolean {
   } catch {
     return false;
   }
-  if (!isErroredSentinel(content)) return false;
-  try {
-    const stat = fs.statSync(summaryPath);
-    return Date.now() - stat.mtimeMs >= getErrorRetryMs();
-  } catch {
-    return false;
+  if (content.length === 0) return false;
+  if (isErroredSentinel(content)) {
+    try {
+      const stat = fs.statSync(summaryPath);
+      return Date.now() - stat.mtimeMs >= getErrorRetryMs();
+    } catch {
+      return false;
+    }
   }
+  const { coverage } = parseSummaryFile(content);
+  if (coverage === null) return false; // legacy; caller must have stamped a baseline via ensureCoverageBaseline
+  return currentArchiveBytes > coverage.bytes;
+}
+
+const DEFAULT_QUIESCENCE_HOURS = 1;
+
+/** Idle time a conversation must reach before it is (re)summarized.
+ *  Allows 0 (summarize immediately, e.g. in tests); rejects negative/garbage. */
+export function getQuiescenceMs(): number {
+  return resolveHoursEnvMs('EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS', DEFAULT_QUIESCENCE_HOURS, true);
+}
+
+/**
+ * True when the conversation has been idle for at least the quiescence window.
+ * Uses the last exchange's timestamp (file mtime is unreliable — the archive
+ * copy's mtime is reset every sync). A missing/unparseable timestamp is treated
+ * as quiescent so it never blocks summarization.
+ */
+export function isQuiescent(exchanges: ConversationExchange[], nowMs: number): boolean {
+  const last = exchanges[exchanges.length - 1];
+  if (!last?.timestamp) return true;
+  const ts = Date.parse(last.timestamp);
+  if (Number.isNaN(ts)) return true;
+  return nowMs - ts >= getQuiescenceMs();
+}
+
+/** Coverage metadata for the conversation currently archived at `archiveJsonlPath`. */
+export function buildCoverage(archiveJsonlPath: string, exchanges: ConversationExchange[]): SummaryCoverage {
+  return {
+    bytes: fs.statSync(archiveJsonlPath).size,
+    lastExchange: exchanges[exchanges.length - 1]?.timestamp,
+    schema: COVERAGE_SCHEMA,
+  };
+}
+
+/** Write a real summary with its coverage header. The single summary-write path. */
+export function writeSummary(
+  summaryPath: string,
+  archiveJsonlPath: string,
+  exchanges: ConversationExchange[],
+  body: string,
+): void {
+  fs.writeFileSync(summaryPath, formatSummaryFile(buildCoverage(archiveJsonlPath, exchanges), body), 'utf-8');
+}
+
+/**
+ * Stamp a legacy (header-less) real summary with current coverage — a header
+ * rewrite, NO LLM call — so existing summaries get a growth baseline without a
+ * mass re-summarization on upgrade. No-op for missing/empty/errored/already-stamped files.
+ */
+export function ensureCoverageBaseline(summaryPath: string, archiveBytes: number): void {
+  if (!fs.existsSync(summaryPath)) return;
+  let content: string;
+  try { content = fs.readFileSync(summaryPath, 'utf-8'); } catch { return; }
+  if (content.length === 0 || isErroredSentinel(content)) return;
+  const { coverage, body } = parseSummaryFile(content);
+  if (coverage !== null) return;
+  fs.writeFileSync(summaryPath, formatSummaryFile({ bytes: archiveBytes, schema: COVERAGE_SCHEMA }, body), 'utf-8');
+}
+
+/**
+ * True when a conversation needs a (re-)summary. Stamps a coverage baseline on a
+ * legacy header-less summary first, so future transcript growth stays detectable.
+ */
+export function needsSummary(summaryPath: string, archiveJsonlPath: string): boolean {
+  const archiveBytes = fs.statSync(archiveJsonlPath).size;
+  ensureCoverageBaseline(summaryPath, archiveBytes);
+  return shouldQueueForSummary(summaryPath, archiveBytes);
 }

--- a/src/summary-sentinel.ts
+++ b/src/summary-sentinel.ts
@@ -22,9 +22,24 @@ const ERROR_MARKER_PREFIX = `${ERROR_MARKER}\n`;
 // milliseconds; convert at this single boundary so the two units never mix.
 const MS_PER_HOUR = 3600_000;
 const DEFAULT_ERROR_RETRY_HOURS = 1;
+const DEFAULT_SUMMARY_MAX_ATTEMPTS = 5;
 
 export const COVERAGE_SCHEMA = 1;
 const COVERAGE_PREFIX = '__COVERAGE__ ';
+
+/**
+ * Attempt-counted failure state shared by both failure stores — the error
+ * sentinel (no good summary yet) and a preserved good summary's `resummary`
+ * field. Drives the unified backoff-and-give-up in shouldRetryAfterFailure: hold
+ * off until the retry floor elapses, then give up once the attempt budget is
+ * spent. Cleared when a summary finally succeeds.
+ */
+export interface FailureState {
+  /** Consecutive failed attempts since the last successful summary. */
+  attempts: number;
+  /** Epoch ms of the last failed attempt — gates the per-attempt retry floor. */
+  lastAttempt: number;
+}
 
 /**
  * Machine-readable header recording how much of a transcript a summary
@@ -37,6 +52,8 @@ export interface SummaryCoverage {
   /** Timestamp of the last exchange the summary covered (diagnostic). */
   lastExchange?: string;
   schema: number;
+  /** Present only after a re-summary has failed; absent on a healthy summary. */
+  resummary?: FailureState;
 }
 
 /** Serialize a real summary with its coverage header as the first line. */
@@ -67,13 +84,36 @@ export function parseSummaryFile(content: string): { coverage: SummaryCoverage |
   return { coverage, body };
 }
 
-export function formatErrorSentinel(error: unknown): string {
+/**
+ * Serialize an error sentinel: the marker, a JSON failure-state line (attempts +
+ * lastAttempt), then the human-readable error message. The failure state lets
+ * shouldQueueForSummary back off and give up identically to a re-summary failure.
+ */
+export function formatErrorSentinel(error: unknown, failure: FailureState): string {
   const message = error instanceof Error ? error.message : String(error);
-  return `${ERROR_MARKER}\n${new Date().toISOString()}\n${message}\n`;
+  return `${ERROR_MARKER}\n${JSON.stringify(failure)}\n${message}\n`;
 }
 
 export function isErroredSentinel(content: string): boolean {
   return content.startsWith(ERROR_MARKER_PREFIX);
+}
+
+/**
+ * Read the failure state from an error sentinel. Tolerates the legacy
+ * `__ERRORED__\n<ISO timestamp>\n<message>` form (no attempt count): the ISO
+ * time becomes lastAttempt and attempts starts at 0, so an upgraded sentinel
+ * keeps backing off correctly and recordSummaryFailure resumes counting.
+ */
+export function parseErrorSentinel(content: string): FailureState {
+  const secondLine = content.split('\n', 2)[1] ?? '';
+  try {
+    const parsed = JSON.parse(secondLine);
+    if (parsed && typeof parsed.attempts === 'number' && typeof parsed.lastAttempt === 'number') {
+      return { attempts: parsed.attempts, lastAttempt: parsed.lastAttempt };
+    }
+  } catch { /* legacy ISO-timestamp form */ }
+  const legacyTime = Date.parse(secondLine);
+  return { attempts: 0, lastAttempt: Number.isNaN(legacyTime) ? 0 : legacyTime };
 }
 
 /** Resolve an `_HOURS` env var to milliseconds, falling back to defaultHours for
@@ -88,8 +128,32 @@ function resolveHoursEnvMs(name: string, defaultHours: number, allowZero: boolea
   return hours * MS_PER_HOUR;
 }
 
-function getErrorRetryMs(): number {
+/** The retry floor: minimum idle time between failed summary attempts (a
+ *  first-time failure or a re-summary alike). Configurable in hours; default 1h. */
+function getRetryFloorMs(): number {
   return resolveHoursEnvMs('EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS', DEFAULT_ERROR_RETRY_HOURS, false);
+}
+
+/**
+ * Failed summary attempts to make before giving up — keeping whatever good
+ * summary exists (none, for a first-time failure). Bounds cost on a transcript
+ * that never summarizes. Configurable for operators/tests; falls back for garbage.
+ */
+export function getMaxSummaryAttempts(): number {
+  const raw = process.env.EPISODIC_MEMORY_SUMMARY_MAX_ATTEMPTS;
+  if (raw === undefined) return DEFAULT_SUMMARY_MAX_ATTEMPTS;
+  const attempts = parseInt(raw, 10);
+  return Number.isInteger(attempts) && attempts >= 0 ? attempts : DEFAULT_SUMMARY_MAX_ATTEMPTS;
+}
+
+/**
+ * The single retry/give-up policy for any recorded summary failure: hold off
+ * until the retry floor has elapsed, then give up once the attempt budget is
+ * spent. Shared by the error-sentinel and re-summary paths so they stay in lockstep.
+ */
+function shouldRetryAfterFailure(failure: FailureState): boolean {
+  if (failure.attempts >= getMaxSummaryAttempts()) return false;
+  return Date.now() - failure.lastAttempt >= getRetryFloorMs();
 }
 
 /**
@@ -112,13 +176,40 @@ export function hasRealSummary(summaryPath: string): boolean {
   return parseSummaryFile(content).body.trim().length > 0;
 }
 
-/**
- * Best-effort error sentinel, written only when no prior real summary exists so a
- * re-summary failure never discards good content. Swallows its own write errors.
- */
-export function writeErrorSentinelIfNew(summaryPath: string, error: unknown): void {
+/** Attempts already recorded in an existing error sentinel, or 0 when there is
+ *  no sentinel (or it can't be read). Lets a repeat first-failure keep counting. */
+function readErrorAttempts(summaryPath: string): number {
   try {
-    if (!hasRealSummary(summaryPath)) fs.writeFileSync(summaryPath, formatErrorSentinel(error), 'utf-8');
+    const content = fs.readFileSync(summaryPath, 'utf-8');
+    return isErroredSentinel(content) ? parseErrorSentinel(content).attempts : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Record a summary failure, incrementing the attempt count. Best-effort —
+ * swallows its own IO errors. Both branches feed the same backoff/give-up policy
+ * (shouldRetryAfterFailure); a successful writeSummary later clears the state.
+ *  - No prior real summary: write an attempt-counted error sentinel (#96).
+ *  - Prior real summary exists: keep the good body but stamp the attempt + time
+ *    into its `resummary` header, so the last good summary survives the failure.
+ */
+export function recordSummaryFailure(summaryPath: string, error: unknown): void {
+  try {
+    const now = Date.now();
+    if (!hasRealSummary(summaryPath)) {
+      const attempts = readErrorAttempts(summaryPath) + 1;
+      fs.writeFileSync(summaryPath, formatErrorSentinel(error, { attempts, lastAttempt: now }), 'utf-8');
+      return;
+    }
+    const { coverage, body } = parseSummaryFile(fs.readFileSync(summaryPath, 'utf-8'));
+    // A legacy header-less good summary is never re-queued (shouldQueueForSummary
+    // returns false for null coverage), so leave it untouched rather than guessing a baseline.
+    if (coverage === null) return;
+    const attempts = (coverage.resummary?.attempts ?? 0) + 1;
+    const updated: SummaryCoverage = { ...coverage, resummary: { attempts, lastAttempt: now } };
+    fs.writeFileSync(summaryPath, formatSummaryFile(updated, body), 'utf-8');
   } catch {}
 }
 
@@ -128,6 +219,10 @@ export function writeErrorSentinelIfNew(summaryPath: string, error: unknown): vo
  *  - a stale error marker, or
  *  - a real summary whose covered byte size is below the current archive size
  *    (the transcript has grown — append-only, so a size increase means new content).
+ * Both a stale error marker and a grown summary carrying failed-re-summary state
+ * are governed by shouldRetryAfterFailure — held back until the retry floor
+ * elapses, then abandoned once getMaxSummaryAttempts() is spent (keeping any good
+ * summary) so a never-summarizable transcript can't thrash.
  * A legacy header-less summary returns false; callers must call
  * ensureCoverageBaseline first so a baseline exists and future growth is detected.
  */
@@ -141,16 +236,15 @@ export function shouldQueueForSummary(summaryPath: string, currentArchiveBytes: 
   }
   if (content.length === 0) return false;
   if (isErroredSentinel(content)) {
-    try {
-      const stat = fs.statSync(summaryPath);
-      return Date.now() - stat.mtimeMs >= getErrorRetryMs();
-    } catch {
-      return false;
-    }
+    return shouldRetryAfterFailure(parseErrorSentinel(content));
   }
   const { coverage } = parseSummaryFile(content);
   if (coverage === null) return false; // legacy; caller must have stamped a baseline via ensureCoverageBaseline
-  return currentArchiveBytes > coverage.bytes;
+  if (currentArchiveBytes <= coverage.bytes) return false; // transcript hasn't grown
+
+  // Transcript grew. A prior failed re-summary backs off / gives up under the
+  // same policy as a first-time failure; otherwise re-summarize the new content.
+  return coverage.resummary ? shouldRetryAfterFailure(coverage.resummary) : true;
 }
 
 const DEFAULT_QUIESCENCE_HOURS = 1;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { SUMMARIZER_CONTEXT_MARKER } from './constants.js';
 import { getExcludedProjects, findJsonlFiles } from './paths.js';
 import {
-  needsSummary, isQuiescent, writeSummary, writeErrorSentinelIfNew,
+  needsSummary, isQuiescent, writeSummary, recordSummaryFailure, hasRealSummary,
 } from './summary-sentinel.js';
 
 const EXCLUSION_MARKERS = [
@@ -68,6 +68,22 @@ export function extractSessionIdFromPath(filePath: string): string | null {
     return matches[matches.length - 1];
   }
   return null;
+}
+
+/**
+ * Order a summary queue so never-summarized conversations come before re-summary
+ * retries (a conversation that already has a good summary). A backlog of growing
+ * or failing re-summaries must not starve fresh work out of the per-run
+ * summaryLimit — the #91 head-of-queue failure mode. Stable within each group.
+ */
+export function orderFreshBeforeRetry<T extends { path: string }>(files: T[]): T[] {
+  const fresh: T[] = [];
+  const retries: T[] = [];
+  for (const file of files) {
+    const summaryPath = file.path.replace('.jsonl', '-summary.txt');
+    (hasRealSummary(summaryPath) ? retries : fresh).push(file);
+  }
+  return [...fresh, ...retries];
 }
 
 export async function syncConversations(
@@ -189,7 +205,7 @@ export async function syncConversations(
     const { summarizeConversation } = await import('./summarizer.js');
 
     const summaryLimit = options.summaryLimit ?? 10;
-    const toSummarize = filesToSummarize.slice(0, summaryLimit);
+    const toSummarize = orderFreshBeforeRetry(filesToSummarize).slice(0, summaryLimit);
     const remaining = filesToSummarize.length - toSummarize.length;
 
     console.log(`Generating summaries for ${toSummarize.length} conversation(s)...`);
@@ -217,7 +233,7 @@ export async function syncConversations(
         writeSummary(summaryPath, filePath, exchanges, summary);
         result.summarized++;
       } catch (error) {
-        writeErrorSentinelIfNew(summaryPath, error);
+        recordSummaryFailure(summaryPath, error);
         result.errors.push({
           file: filePath,
           error: `Summary generation failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2,7 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import { SUMMARIZER_CONTEXT_MARKER } from './constants.js';
 import { getExcludedProjects, findJsonlFiles } from './paths.js';
-import { formatErrorSentinel, shouldQueueForSummary } from './summary-sentinel.js';
+import {
+  needsSummary, isQuiescent, writeSummary, writeErrorSentinelIfNew,
+} from './summary-sentinel.js';
 
 const EXCLUSION_MARKERS = [
   '<INSTRUCTIONS-TO-EPISODIC-MEMORY>DO NOT INDEX THIS CHAT</INSTRUCTIONS-TO-EPISODIC-MEMORY>',
@@ -122,11 +124,9 @@ export async function syncConversations(
         }
 
         // Check if this file needs a summary (whether newly copied or existing).
-        // shouldQueueForSummary skips files that already have a real summary or
-        // an empty zero-exchange sentinel, and retries stale error sentinels (#96).
         if (!options.skipSummaries) {
           const summaryPath = destFile.replace('.jsonl', '-summary.txt');
-          if (shouldQueueForSummary(summaryPath) && !shouldSkipConversation(destFile)) {
+          if (needsSummary(summaryPath, destFile) && !shouldSkipConversation(destFile)) {
             const sessionId = extractSessionIdFromPath(destFile);
             if (sessionId) {
               filesToSummarize.push({ path: destFile, sessionId });
@@ -198,36 +198,29 @@ export async function syncConversations(
     }
 
     for (const { path: filePath, sessionId } of toSummarize) {
+      const summaryPath = filePath.replace('.jsonl', '-summary.txt');
       try {
         const project = path.basename(path.dirname(filePath));
         const exchanges = await parseConversation(filePath, project, filePath);
 
         if (exchanges.length === 0) {
-          // Skip empty conversations — write an empty -summary.txt sentinel so they aren't re-queued forever
-          const summaryPath = filePath.replace('.jsonl', '-summary.txt');
-          fs.writeFileSync(summaryPath, '', 'utf-8');
+          fs.writeFileSync(summaryPath, '', 'utf-8'); // empty zero-exchange sentinel
           continue;
         }
 
+        // Only summarize once the conversation is quiescent, so we never freeze a
+        // mid-session snapshot. A non-quiescent file is left as-is and re-queued next sync.
+        if (!isQuiescent(exchanges, Date.now())) continue;
+
         console.log(`  Summarizing ${path.basename(filePath)} (${exchanges.length} exchanges)...`);
         const summary = await summarizeConversation(exchanges, sessionId);
-
-        const summaryPath = filePath.replace('.jsonl', '-summary.txt');
-        fs.writeFileSync(summaryPath, summary, 'utf-8');
+        writeSummary(summaryPath, filePath, exchanges, summary);
         result.summarized++;
       } catch (error) {
-        // Write a structured error sentinel (#96): distinct from the empty
-        // zero-exchange sentinel so a stale failure can self-heal on the next
-        // sync run past the retry threshold. The marker also keeps the error
-        // text on disk for post-hoc diagnosis. Best-effort — if the sentinel
-        // write itself fails, fall through and surface the original error.
-        try {
-          const summaryPath = filePath.replace('.jsonl', '-summary.txt');
-          fs.writeFileSync(summaryPath, formatErrorSentinel(error), 'utf-8');
-        } catch {}
+        writeErrorSentinelIfNew(summaryPath, error);
         result.errors.push({
           file: filePath,
-          error: `Summary generation failed: ${error instanceof Error ? error.message : String(error)}`
+          error: `Summary generation failed: ${error instanceof Error ? error.message : String(error)}`,
         });
       }
     }

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { parseConversation } from './parser.js';
 import { initDatabase, getAllExchanges, getFileLastIndexed } from './db.js';
 import { getArchiveDir, getExcludedProjects, findJsonlFiles } from './paths.js';
-import { isErroredSentinel } from './summary-sentinel.js';
+import { isErroredSentinel, writeSummary } from './summary-sentinel.js';
 
 export interface VerificationResult {
   missing: Array<{ path: string; reason: string }>;
@@ -161,7 +161,7 @@ export async function repairIndex(issues: VerificationResult): Promise<void> {
       // Generate/update summary
       const summaryPath = conversationPath.replace('.jsonl', '-summary.txt');
       const summary = await summarizeConversation(exchanges);
-      fs.writeFileSync(summaryPath, summary, 'utf-8');
+      writeSummary(summaryPath, conversationPath, exchanges, summary);
       console.log(`  Created summary: ${summary.split(/\s+/).length} words`);
 
       // Index exchanges

--- a/test/search-summary-strip.test.ts
+++ b/test/search-summary-strip.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { parseSummaryFile, formatSummaryFile, COVERAGE_SCHEMA } from '../src/summary-sentinel.js';
+
+// The search loader must show the body, never the __COVERAGE__ header line.
+describe('search summary display', () => {
+  it('parseSummaryFile yields a header-free body for display', () => {
+    const file = formatSummaryFile({ bytes: 10, schema: COVERAGE_SCHEMA }, 'Visible summary.');
+    expect(parseSummaryFile(file).body.trim()).toBe('Visible summary.');
+    expect(parseSummaryFile(file).body).not.toContain('__COVERAGE__');
+  });
+});

--- a/test/show.test.ts
+++ b/test/show.test.ts
@@ -182,8 +182,8 @@ describe('show command - markdown formatting', () => {
     expect(markdown).toMatch(/\*\*Agent\*\*/);
     expect(markdown).toContain('Looking at your instructions');
 
-    // Should show timestamps
-    expect(markdown).toMatch(/9\/19\/2025|2025-09-19/);
+    const expectedTimestamp = new Date('2025-09-19T17:34:29.181Z').toLocaleString();
+    expect(markdown).toContain(expectedTimestamp);
   });
 
   it('should include tool calls in the output', () => {

--- a/test/summary-coverage.test.ts
+++ b/test/summary-coverage.test.ts
@@ -86,7 +86,7 @@ describe('writeSummary + ensureCoverageBaseline', () => {
 
   it('leaves an error sentinel untouched', () => {
     const summaryPath = join(tmp(), 's-summary.txt');
-    const errored = formatErrorSentinel(new Error('boom'));
+    const errored = formatErrorSentinel(new Error('boom'), { attempts: 1, lastAttempt: Date.now() });
     writeFileSync(summaryPath, errored);
     ensureCoverageBaseline(summaryPath, 999);
     expect(readFileSync(summaryPath, 'utf-8')).toBe(errored);

--- a/test/summary-coverage.test.ts
+++ b/test/summary-coverage.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { formatSummaryFile, parseSummaryFile, COVERAGE_SCHEMA, writeSummary, ensureCoverageBaseline, formatErrorSentinel } from '../src/summary-sentinel.js';
+import { mkdtempSync, writeFileSync, readFileSync, statSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('summary coverage codec', () => {
+  it('round-trips a coverage header and body', () => {
+    const cov = { bytes: 48213, lastExchange: '2026-06-07T14:03:22Z', schema: COVERAGE_SCHEMA };
+    const file = formatSummaryFile(cov, 'A short summary.');
+    expect(file.startsWith('__COVERAGE__ ')).toBe(true);
+    const { coverage, body } = parseSummaryFile(file);
+    expect(coverage).toEqual(cov);
+    expect(body).toBe('A short summary.');
+  });
+
+  it('treats a header-less file as legacy (no coverage, whole content is body)', () => {
+    const { coverage, body } = parseSummaryFile('Legacy summary text.');
+    expect(coverage).toBeNull();
+    expect(body).toBe('Legacy summary text.');
+  });
+
+  it('strips a corrupt header line rather than leaking it into the body', () => {
+    const { coverage, body } = parseSummaryFile('__COVERAGE__ {not json\nThe summary.');
+    expect(coverage).toBeNull();
+    expect(body).toBe('The summary.');
+  });
+
+  it('parses a header with no trailing newline as an empty body', () => {
+    const { coverage, body } = parseSummaryFile('__COVERAGE__ {"bytes":10,"schema":1}');
+    expect(coverage).toEqual({ bytes: 10, schema: 1 });
+    expect(body).toBe('');
+  });
+
+  it('round-trips a multi-line body', () => {
+    const cov = { bytes: 1, schema: COVERAGE_SCHEMA };
+    const body = 'Line one.\nLine two.\n\nLine four.';
+    expect(parseSummaryFile(formatSummaryFile(cov, body)).body).toBe(body);
+  });
+});
+
+describe('writeSummary + ensureCoverageBaseline', () => {
+  const tmpDirs: string[] = [];
+  const tmp = () => { const d = mkdtempSync(join(tmpdir(), 'cov-')); tmpDirs.push(d); return d; };
+  afterEach(() => { for (const d of tmpDirs.splice(0)) rmSync(d, { recursive: true, force: true }); });
+
+  it('writes a summary stamped with the archive byte size and last timestamp', () => {
+    const dir = tmp();
+    const jsonl = join(dir, 's.jsonl');
+    writeFileSync(jsonl, 'x'.repeat(500));
+    const summaryPath = join(dir, 's-summary.txt');
+    const exchanges = [{ timestamp: '2026-06-07T10:00:00Z' }, { timestamp: '2026-06-07T11:00:00Z' }] as any;
+    writeSummary(summaryPath, jsonl, exchanges, 'The summary body.');
+    const { coverage, body } = parseSummaryFile(readFileSync(summaryPath, 'utf-8'));
+    expect(coverage?.bytes).toBe(statSync(jsonl).size);
+    expect(coverage?.lastExchange).toBe('2026-06-07T11:00:00Z');
+    expect(body).toBe('The summary body.');
+  });
+
+  it('stamps a legacy header-less summary with current bytes and no LLM, preserving the body', () => {
+    const dir = tmp();
+    const jsonl = join(dir, 's.jsonl');
+    writeFileSync(jsonl, 'y'.repeat(800));
+    const summaryPath = join(dir, 's-summary.txt');
+    writeFileSync(summaryPath, 'Old legacy summary.');
+    ensureCoverageBaseline(summaryPath, statSync(jsonl).size);
+    const { coverage, body } = parseSummaryFile(readFileSync(summaryPath, 'utf-8'));
+    expect(coverage?.bytes).toBe(800);
+    expect(body).toBe('Old legacy summary.');
+  });
+
+  it('leaves an already-stamped file untouched', () => {
+    const summaryPath = join(tmp(), 's-summary.txt');
+    const stamped = formatSummaryFile({ bytes: 10, schema: COVERAGE_SCHEMA }, 'Body');
+    writeFileSync(summaryPath, stamped);
+    ensureCoverageBaseline(summaryPath, 999);
+    expect(readFileSync(summaryPath, 'utf-8')).toBe(stamped);
+  });
+
+  it('leaves an empty zero-exchange sentinel untouched', () => {
+    const summaryPath = join(tmp(), 's-summary.txt');
+    writeFileSync(summaryPath, '');
+    ensureCoverageBaseline(summaryPath, 999);
+    expect(readFileSync(summaryPath, 'utf-8')).toBe('');
+  });
+
+  it('leaves an error sentinel untouched', () => {
+    const summaryPath = join(tmp(), 's-summary.txt');
+    const errored = formatErrorSentinel(new Error('boom'));
+    writeFileSync(summaryPath, errored);
+    ensureCoverageBaseline(summaryPath, 999);
+    expect(readFileSync(summaryPath, 'utf-8')).toBe(errored);
+  });
+});

--- a/test/summary-queue-order.test.ts
+++ b/test/summary-queue-order.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { orderFreshBeforeRetry } from '../src/sync.js';
+import { formatSummaryFile, COVERAGE_SCHEMA } from '../src/summary-sentinel.js';
+
+const dirs: string[] = [];
+function tmp() { const d = mkdtempSync(join(tmpdir(), 'queue-order-')); dirs.push(d); return d; }
+afterEach(() => { for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true }); });
+
+// A conversation is a "re-summary" when its -summary.txt already holds a real
+// body; those must sort AFTER never-summarized ones so a backlog of failing
+// re-summaries can't starve fresh work out of the per-run summaryLimit (#91).
+function writeGoodSummary(jsonlPath: string): void {
+  writeFileSync(jsonlPath.replace('.jsonl', '-summary.txt'),
+    formatSummaryFile({ bytes: 1, schema: COVERAGE_SCHEMA }, 'Existing summary'));
+}
+
+describe('orderFreshBeforeRetry', () => {
+  it('puts never-summarized conversations ahead of re-summary retries', () => {
+    const dir = tmp();
+    const fresh = { path: join(dir, 'fresh.jsonl'), sessionId: 'f' };
+    const retry = { path: join(dir, 'retry.jsonl'), sessionId: 'r' };
+    writeFileSync(fresh.path, '{}');
+    writeFileSync(retry.path, '{}');
+    writeGoodSummary(retry.path);
+
+    // Input deliberately retry-first; output must be fresh-first.
+    const ordered = orderFreshBeforeRetry([retry, fresh]);
+    expect(ordered.map(f => f.sessionId)).toEqual(['f', 'r']);
+  });
+
+  it('preserves discovery order within each group (stable)', () => {
+    const dir = tmp();
+    const items = ['f1', 'f2', 'r1', 'r2'].map(id => ({ path: join(dir, `${id}.jsonl`), sessionId: id }));
+    for (const f of items) writeFileSync(f.path, '{}');
+    writeGoodSummary(items[2].path); // r1
+    writeGoodSummary(items[3].path); // r2
+
+    const ordered = orderFreshBeforeRetry([items[0], items[2], items[1], items[3]]); // f1, r1, f2, r2
+    expect(ordered.map(f => f.sessionId)).toEqual(['f1', 'f2', 'r1', 'r2']);
+  });
+});

--- a/test/summary-quiescence.test.ts
+++ b/test/summary-quiescence.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getQuiescenceMs, isQuiescent } from '../src/summary-sentinel.js';
+
+const ENV = 'EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS';
+afterEach(() => { delete process.env[ENV]; });
+
+describe('quiescence', () => {
+  it('defaults to one hour', () => {
+    expect(getQuiescenceMs()).toBe(3600_000);
+  });
+
+  it('honors the env override, including 0 (no wait)', () => {
+    process.env[ENV] = '2';
+    expect(getQuiescenceMs()).toBe(7200_000);
+    process.env[ENV] = '0';
+    expect(getQuiescenceMs()).toBe(0);
+  });
+
+  it('falls back to the default for a non-positive/garbage value', () => {
+    process.env[ENV] = 'nope';
+    expect(getQuiescenceMs()).toBe(3600_000);
+    process.env[ENV] = '-1';
+    expect(getQuiescenceMs()).toBe(3600_000);
+  });
+
+  it('is quiescent only when the last exchange is older than the threshold', () => {
+    const now = 1_000_000_000_000;
+    const recent = [{ timestamp: new Date(now - 60_000).toISOString() }] as any;
+    const old = [{ timestamp: new Date(now - 7200_000).toISOString() }] as any;
+    expect(isQuiescent(recent, now)).toBe(false);
+    expect(isQuiescent(old, now)).toBe(true);
+  });
+
+  it('treats a missing/unparseable last timestamp as quiescent (cannot tell, do not block)', () => {
+    expect(isQuiescent([], 1_000_000_000_000)).toBe(true);
+    expect(isQuiescent([{ timestamp: 'garbage' }] as any, 1_000_000_000_000)).toBe(true);
+  });
+
+  it('treats an exchange aged exactly the threshold as quiescent (>= boundary)', () => {
+    const now = 1_000_000_000_000;
+    const atThreshold = [{ timestamp: new Date(now - 3600_000).toISOString() }] as any;
+    const justUnder = [{ timestamp: new Date(now - 3600_000 + 1).toISOString() }] as any;
+    expect(isQuiescent(atThreshold, now)).toBe(true);
+    expect(isQuiescent(justUnder, now)).toBe(false);
+  });
+});

--- a/test/summary-sentinel.test.ts
+++ b/test/summary-sentinel.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  shouldQueueForSummary, hasRealSummary, formatSummaryFile, parseSummaryFile,
+  formatErrorSentinel, isErroredSentinel, needsSummary, writeErrorSentinelIfNew,
+  COVERAGE_SCHEMA,
+} from '../src/summary-sentinel.js';
+
+const dirs: string[] = [];
+function tmp() { const d = mkdtempSync(join(tmpdir(), 'gate-')); dirs.push(d); return d; }
+afterEach(() => { for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true }); });
+
+describe('shouldQueueForSummary (growth-aware)', () => {
+  it('queues when there is no summary file', () => {
+    expect(shouldQueueForSummary(join(tmp(), 's-summary.txt'), 100)).toBe(true);
+  });
+
+  it('skips an empty zero-exchange sentinel', () => {
+    const p = join(tmp(), 's-summary.txt'); writeFileSync(p, '');
+    expect(shouldQueueForSummary(p, 100)).toBe(false);
+  });
+
+  it('skips a real summary whose covered bytes equal the current archive size', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatSummaryFile({ bytes: 500, schema: COVERAGE_SCHEMA }, 'Summary'));
+    expect(shouldQueueForSummary(p, 500)).toBe(false);
+  });
+
+  it('re-queues a real summary when the archive has grown past covered bytes', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatSummaryFile({ bytes: 500, schema: COVERAGE_SCHEMA }, 'Summary'));
+    expect(shouldQueueForSummary(p, 900)).toBe(true);
+  });
+
+  it('does not re-queue a legacy header-less summary (baseline stamping handles it)', () => {
+    const p = join(tmp(), 's-summary.txt'); writeFileSync(p, 'Legacy summary, no header');
+    expect(shouldQueueForSummary(p, 900)).toBe(false);
+  });
+
+  it('does not retry a recent error sentinel', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatErrorSentinel(new Error('boom')));
+    expect(shouldQueueForSummary(p, 100)).toBe(false);
+  });
+
+  it('treats a corrupt coverage header as legacy and does not re-queue', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, '__COVERAGE__ {not json\nSummary body');
+    expect(shouldQueueForSummary(p, 9999)).toBe(false);
+  });
+
+  it('does not re-queue when the archive is smaller than covered bytes', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatSummaryFile({ bytes: 500, schema: COVERAGE_SCHEMA }, 'Summary'));
+    expect(shouldQueueForSummary(p, 300)).toBe(false);
+  });
+});
+
+describe('hasRealSummary', () => {
+  it('is true for a stamped summary with a non-empty body', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatSummaryFile({ bytes: 1, schema: COVERAGE_SCHEMA }, 'Real body'));
+    expect(hasRealSummary(p)).toBe(true);
+  });
+
+  it('is false for a header with an empty body', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatSummaryFile({ bytes: 1, schema: COVERAGE_SCHEMA }, ''));
+    expect(hasRealSummary(p)).toBe(false);
+  });
+});
+
+describe('needsSummary (stat + baseline + growth verdict)', () => {
+  it('queues when there is no summary file', () => {
+    const dir = tmp();
+    const archive = join(dir, 's.jsonl'); writeFileSync(archive, 'x'.repeat(100));
+    expect(needsSummary(join(dir, 's-summary.txt'), archive)).toBe(true);
+  });
+
+  it('stamps a legacy summary with the current archive size and does not re-queue', () => {
+    const dir = tmp();
+    const archive = join(dir, 's.jsonl'); writeFileSync(archive, 'x'.repeat(800));
+    const summary = join(dir, 's-summary.txt'); writeFileSync(summary, 'Legacy summary, no header');
+    expect(needsSummary(summary, archive)).toBe(false);
+    expect(parseSummaryFile(readFileSync(summary, 'utf-8')).coverage?.bytes).toBe(800);
+  });
+
+  it('re-queues a stamped summary when the archive has grown', () => {
+    const dir = tmp();
+    const archive = join(dir, 's.jsonl'); writeFileSync(archive, 'x'.repeat(900));
+    const summary = join(dir, 's-summary.txt');
+    writeFileSync(summary, formatSummaryFile({ bytes: 500, schema: COVERAGE_SCHEMA }, 'Summary'));
+    expect(needsSummary(summary, archive)).toBe(true);
+  });
+});
+
+describe('writeErrorSentinelIfNew', () => {
+  it('writes an error sentinel when no prior summary exists', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeErrorSentinelIfNew(p, new Error('boom'));
+    expect(isErroredSentinel(readFileSync(p, 'utf-8'))).toBe(true);
+  });
+
+  it('preserves a prior real summary instead of overwriting it', () => {
+    const p = join(tmp(), 's-summary.txt');
+    const good = formatSummaryFile({ bytes: 1, schema: COVERAGE_SCHEMA }, 'Real body');
+    writeFileSync(p, good);
+    writeErrorSentinelIfNew(p, new Error('boom'));
+    expect(readFileSync(p, 'utf-8')).toBe(good);
+  });
+});

--- a/test/summary-sentinel.test.ts
+++ b/test/summary-sentinel.test.ts
@@ -4,13 +4,19 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   shouldQueueForSummary, hasRealSummary, formatSummaryFile, parseSummaryFile,
-  formatErrorSentinel, isErroredSentinel, needsSummary, writeErrorSentinelIfNew,
-  COVERAGE_SCHEMA,
+  formatErrorSentinel, parseErrorSentinel, isErroredSentinel, needsSummary,
+  recordSummaryFailure, getMaxSummaryAttempts, COVERAGE_SCHEMA,
 } from '../src/summary-sentinel.js';
 
 const dirs: string[] = [];
 function tmp() { const d = mkdtempSync(join(tmpdir(), 'gate-')); dirs.push(d); return d; }
-afterEach(() => { for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true }); });
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  delete process.env.EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS;
+  delete process.env.EPISODIC_MEMORY_SUMMARY_MAX_ATTEMPTS;
+});
+
+const recentFailure = () => ({ attempts: 1, lastAttempt: Date.now() });
 
 describe('shouldQueueForSummary (growth-aware)', () => {
   it('queues when there is no summary file', () => {
@@ -41,7 +47,7 @@ describe('shouldQueueForSummary (growth-aware)', () => {
 
   it('does not retry a recent error sentinel', () => {
     const p = join(tmp(), 's-summary.txt');
-    writeFileSync(p, formatErrorSentinel(new Error('boom')));
+    writeFileSync(p, formatErrorSentinel(new Error('boom'), recentFailure()));
     expect(shouldQueueForSummary(p, 100)).toBe(false);
   });
 
@@ -55,6 +61,63 @@ describe('shouldQueueForSummary (growth-aware)', () => {
     const p = join(tmp(), 's-summary.txt');
     writeFileSync(p, formatSummaryFile({ bytes: 500, schema: COVERAGE_SCHEMA }, 'Summary'));
     expect(shouldQueueForSummary(p, 300)).toBe(false);
+  });
+
+  // --- Unified backoff/give-up: same policy for first-failure sentinels and re-summaries. ---
+
+  it('re-queues an error sentinel once the retry floor has elapsed', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatErrorSentinel(new Error('boom'), { attempts: 1, lastAttempt: Date.now() - 2 * 3600_000 }));
+    expect(shouldQueueForSummary(p, 100)).toBe(true);
+  });
+
+  it('gives up an error sentinel after the max attempts, even past the floor', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatErrorSentinel(new Error('boom'), { attempts: getMaxSummaryAttempts(), lastAttempt: Date.now() - 999 * 3600_000 }));
+    expect(shouldQueueForSummary(p, 100)).toBe(false);
+  });
+
+  it('backs off a recently-failed re-summary even though the transcript has grown', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatSummaryFile(
+      { bytes: 500, schema: COVERAGE_SCHEMA, resummary: { attempts: 1, lastAttempt: Date.now() } },
+      'Summary'));
+    // Grown (900 > 500) but the last failure was just now — the 1h floor hasn't elapsed.
+    expect(shouldQueueForSummary(p, 900)).toBe(false);
+  });
+
+  it('retries a grown re-summary once the retry floor has elapsed', () => {
+    const p = join(tmp(), 's-summary.txt');
+    const twoHoursAgo = Date.now() - 2 * 3600_000;
+    writeFileSync(p, formatSummaryFile(
+      { bytes: 500, schema: COVERAGE_SCHEMA, resummary: { attempts: 1, lastAttempt: twoHoursAgo } },
+      'Summary'));
+    expect(shouldQueueForSummary(p, 900)).toBe(true);
+  });
+
+  it('gives up permanently after the max re-summary attempts, keeping the stale summary', () => {
+    const p = join(tmp(), 's-summary.txt');
+    const longAgo = Date.now() - 999 * 3600_000;
+    writeFileSync(p, formatSummaryFile(
+      { bytes: 500, schema: COVERAGE_SCHEMA, resummary: { attempts: getMaxSummaryAttempts(), lastAttempt: longAgo } },
+      'Summary'));
+    // Floor long elapsed and the transcript keeps growing — but the attempt budget is spent.
+    expect(shouldQueueForSummary(p, 900)).toBe(false);
+    expect(shouldQueueForSummary(p, 100_000)).toBe(false);
+  });
+
+  it('honors EPISODIC_MEMORY_SUMMARY_MAX_ATTEMPTS for the give-up threshold (both paths)', () => {
+    process.env.EPISODIC_MEMORY_SUMMARY_MAX_ATTEMPTS = '2';
+    const longAgo = Date.now() - 999 * 3600_000;
+    const errored = join(tmp(), 'e-summary.txt');
+    writeFileSync(errored, formatErrorSentinel(new Error('boom'), { attempts: 2, lastAttempt: longAgo }));
+    expect(shouldQueueForSummary(errored, 100)).toBe(false);
+
+    const grown = join(tmp(), 'g-summary.txt');
+    writeFileSync(grown, formatSummaryFile(
+      { bytes: 500, schema: COVERAGE_SCHEMA, resummary: { attempts: 2, lastAttempt: longAgo } },
+      'Summary'));
+    expect(shouldQueueForSummary(grown, 900)).toBe(false);
   });
 });
 
@@ -96,18 +159,73 @@ describe('needsSummary (stat + baseline + growth verdict)', () => {
   });
 });
 
-describe('writeErrorSentinelIfNew', () => {
+describe('recordSummaryFailure', () => {
   it('writes an error sentinel when no prior summary exists', () => {
     const p = join(tmp(), 's-summary.txt');
-    writeErrorSentinelIfNew(p, new Error('boom'));
+    recordSummaryFailure(p, new Error('boom'));
     expect(isErroredSentinel(readFileSync(p, 'utf-8'))).toBe(true);
   });
 
-  it('preserves a prior real summary instead of overwriting it', () => {
+  it('increments the error sentinel attempt count across first-failure retries', () => {
     const p = join(tmp(), 's-summary.txt');
-    const good = formatSummaryFile({ bytes: 1, schema: COVERAGE_SCHEMA }, 'Real body');
-    writeFileSync(p, good);
-    writeErrorSentinelIfNew(p, new Error('boom'));
-    expect(readFileSync(p, 'utf-8')).toBe(good);
+    recordSummaryFailure(p, new Error('boom'));
+    expect(parseErrorSentinel(readFileSync(p, 'utf-8')).attempts).toBe(1);
+    recordSummaryFailure(p, new Error('boom again'));
+    expect(parseErrorSentinel(readFileSync(p, 'utf-8')).attempts).toBe(2);
+  });
+
+  it('preserves a prior real summary body instead of overwriting it with an error', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatSummaryFile({ bytes: 1, schema: COVERAGE_SCHEMA }, 'Real body'));
+    recordSummaryFailure(p, new Error('boom'));
+    const content = readFileSync(p, 'utf-8');
+    expect(isErroredSentinel(content)).toBe(false);
+    expect(parseSummaryFile(content).body).toBe('Real body');
+  });
+
+  it('stamps an incrementing re-summary attempt count on the preserved summary', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatSummaryFile({ bytes: 1, schema: COVERAGE_SCHEMA }, 'Real body'));
+    recordSummaryFailure(p, new Error('boom'));
+    expect(parseSummaryFile(readFileSync(p, 'utf-8')).coverage?.resummary?.attempts).toBe(1);
+    recordSummaryFailure(p, new Error('boom again'));
+    expect(parseSummaryFile(readFileSync(p, 'utf-8')).coverage?.resummary?.attempts).toBe(2);
+  });
+
+  it('keeps the covered byte size unchanged so growth stays the re-queue signal', () => {
+    const p = join(tmp(), 's-summary.txt');
+    writeFileSync(p, formatSummaryFile({ bytes: 500, schema: COVERAGE_SCHEMA }, 'Real body'));
+    recordSummaryFailure(p, new Error('boom'));
+    expect(parseSummaryFile(readFileSync(p, 'utf-8')).coverage?.bytes).toBe(500);
+  });
+});
+
+describe('parseErrorSentinel', () => {
+  it('round-trips attempts and lastAttempt', () => {
+    const s = formatErrorSentinel(new Error('boom'), { attempts: 3, lastAttempt: 1718000000000 });
+    expect(parseErrorSentinel(s)).toEqual({ attempts: 3, lastAttempt: 1718000000000 });
+  });
+
+  it('reads a legacy ISO-timestamp sentinel as attempts 0 with the parsed time', () => {
+    const iso = '2026-06-07T10:00:00.000Z';
+    const parsed = parseErrorSentinel(`__ERRORED__\n${iso}\nboom\n`);
+    expect(parsed.attempts).toBe(0);
+    expect(parsed.lastAttempt).toBe(Date.parse(iso));
+  });
+});
+
+describe('getMaxSummaryAttempts', () => {
+  it('defaults to 5', () => {
+    expect(getMaxSummaryAttempts()).toBe(5);
+  });
+
+  it('honors a valid env override', () => {
+    process.env.EPISODIC_MEMORY_SUMMARY_MAX_ATTEMPTS = '3';
+    expect(getMaxSummaryAttempts()).toBe(3);
+  });
+
+  it('falls back to the default for a garbage value', () => {
+    process.env.EPISODIC_MEMORY_SUMMARY_MAX_ATTEMPTS = 'nope';
+    expect(getMaxSummaryAttempts()).toBe(5);
   });
 });

--- a/test/sync-error-sentinel.test.ts
+++ b/test/sync-error-sentinel.test.ts
@@ -16,7 +16,7 @@ vi.mock('../src/summarizer.js', async () => {
 
 import { syncConversations } from '../src/sync.js';
 import { summarizeConversation } from '../src/summarizer.js';
-import { ERROR_MARKER, isErroredSentinel, shouldQueueForSummary, formatErrorSentinel } from '../src/summary-sentinel.js';
+import { ERROR_MARKER, isErroredSentinel, shouldQueueForSummary, formatErrorSentinel, parseSummaryFile } from '../src/summary-sentinel.js';
 
 function makeNonEmptyJsonl(sessionId: string): string {
   return [
@@ -52,10 +52,14 @@ describe('sync command — error-sentinel + retry behavior (#96)', () => {
     mkdirSync(sourceDir, { recursive: true });
     vi.mocked(summarizeConversation).mockReset();
     delete process.env.EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS;
+    // Disable the quiescence gate (default 1h idle) so summaries are produced
+    // synchronously from fixtures during the test run.
+    process.env.EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS = '0';
   });
 
   afterEach(() => {
     delete process.env.EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS;
+    delete process.env.EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS;
     try {
       rmSync(testDir, { recursive: true, force: true });
     } catch {}
@@ -121,7 +125,8 @@ describe('sync command — error-sentinel + retry behavior (#96)', () => {
 
     expect(vi.mocked(summarizeConversation).mock.calls.length).toBe(2);
     expect(r2.summarized).toBe(1);
-    expect(readFileSync(summaryPath, 'utf-8')).toBe('Recovered summary.');
+    // Real summaries now carry a __COVERAGE__ header; compare only the body.
+    expect(parseSummaryFile(readFileSync(summaryPath, 'utf-8')).body).toBe('Recovered summary.');
   });
 
   it('respects EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS for the retry threshold', async () => {
@@ -175,12 +180,13 @@ describe('sync command — error-sentinel + retry behavior (#96)', () => {
     // skip; #91) from __ERRORED__ (transient; retry after threshold).
     const sentinelPath = join(testDir, 'empty-summary.txt');
     writeFileSync(sentinelPath, '', 'utf-8');
-    expect(shouldQueueForSummary(sentinelPath)).toBe(false);
+    // Byte arg is irrelevant for the empty (permanent-skip) path; pass 0.
+    expect(shouldQueueForSummary(sentinelPath, 0)).toBe(false);
 
     // Even if the empty sentinel is ancient, it must not be re-queued.
     const ancient = new Date(Date.now() - 365 * 24 * 3600_000);
     utimesSync(sentinelPath, ancient, ancient);
-    expect(shouldQueueForSummary(sentinelPath)).toBe(false);
+    expect(shouldQueueForSummary(sentinelPath, 0)).toBe(false);
   });
 
   it('formatErrorSentinel + isErroredSentinel round-trip', () => {

--- a/test/sync-error-sentinel.test.ts
+++ b/test/sync-error-sentinel.test.ts
@@ -81,9 +81,11 @@ describe('sync command — error-sentinel + retry behavior (#96)', () => {
     const content = readFileSync(summaryPath, 'utf-8');
     expect(content.startsWith(`${ERROR_MARKER}\n`)).toBe(true);
     expect(content).toContain('Simulated API outage');
-    // Second line should be an ISO timestamp — sanity check that it parses.
-    const [, ts] = content.split('\n');
-    expect(Number.isFinite(Date.parse(ts))).toBe(true);
+    // Second line is the JSON failure state — records the attempt count and time.
+    const [, stateLine] = content.split('\n');
+    const failure = JSON.parse(stateLine);
+    expect(failure.attempts).toBe(1);
+    expect(Number.isFinite(failure.lastAttempt)).toBe(true);
   });
 
   it('does not re-queue an errored file on an immediate second sync (within retry window)', async () => {
@@ -115,9 +117,8 @@ describe('sync command — error-sentinel + retry behavior (#96)', () => {
     const summaryPath = join(destDir, 'project-a', `${sessionId}-summary.txt`);
     expect(isErroredSentinel(readFileSync(summaryPath, 'utf-8'))).toBe(true);
 
-    // Backdate the sentinel's mtime past the default 1h retry window.
-    const twoHoursAgo = new Date(Date.now() - 2 * 3600_000);
-    utimesSync(summaryPath, twoHoursAgo, twoHoursAgo);
+    // Backdate the sentinel's recorded attempt past the default 1h retry window.
+    writeFileSync(summaryPath, formatErrorSentinel(new Error('Transient API outage'), { attempts: 1, lastAttempt: Date.now() - 2 * 3600_000 }), 'utf-8');
 
     // Second sync — now the file should be re-attempted. This time it succeeds.
     vi.mocked(summarizeConversation).mockResolvedValueOnce('Recovered summary.');
@@ -139,9 +140,8 @@ describe('sync command — error-sentinel + retry behavior (#96)', () => {
     await syncConversations(sourceDir, destDir, { skipIndex: true });
     const summaryPath = join(destDir, 'project-a', `${sessionId}-summary.txt`);
 
-    // Backdate sentinel by 1 minute — well past the 36-second threshold.
-    const oneMinuteAgo = new Date(Date.now() - 60_000);
-    utimesSync(summaryPath, oneMinuteAgo, oneMinuteAgo);
+    // Backdate the recorded attempt by 1 minute — well past the 36-second threshold.
+    writeFileSync(summaryPath, formatErrorSentinel(new Error('Outage'), { attempts: 1, lastAttempt: Date.now() - 60_000 }), 'utf-8');
 
     vi.mocked(summarizeConversation).mockResolvedValueOnce('Recovered.');
     const r2 = await syncConversations(sourceDir, destDir, { skipIndex: true });
@@ -190,7 +190,7 @@ describe('sync command — error-sentinel + retry behavior (#96)', () => {
   });
 
   it('formatErrorSentinel + isErroredSentinel round-trip', () => {
-    const s = formatErrorSentinel(new Error('boom'));
+    const s = formatErrorSentinel(new Error('boom'), { attempts: 1, lastAttempt: Date.now() });
     expect(isErroredSentinel(s)).toBe(true);
     expect(s).toContain('boom');
     expect(isErroredSentinel('Real summary content.')).toBe(false);
@@ -231,7 +231,7 @@ describe('hasRealSummary helper', () => {
   it('returns false for error sentinels (#96) — they are not real coverage', async () => {
     const { hasRealSummary } = await import('../src/summary-sentinel.js');
     const p = join(testDir, 'errored.txt');
-    writeFileSync(p, formatErrorSentinel(new Error('outage')), 'utf-8');
+    writeFileSync(p, formatErrorSentinel(new Error('outage'), { attempts: 1, lastAttempt: Date.now() }), 'utf-8');
     expect(hasRealSummary(p)).toBe(false);
   });
 });

--- a/test/sync-resummary.test.ts
+++ b/test/sync-resummary.test.ts
@@ -182,5 +182,9 @@ describe('sync command — self-healing (growth-driven) re-summary', () => {
     const content = readFileSync(summaryPath(), 'utf-8');
     expect(isErroredSentinel(content)).toBe(false);
     expect(parseSummaryFile(content).body).toBe('Good summary.');
+
+    // ...but the failure is recorded so the growth gate can back off and eventually
+    // give up rather than re-attempting on every sync (no-backoff thrash).
+    expect(parseSummaryFile(content).coverage?.resummary?.attempts).toBe(1);
   });
 });

--- a/test/sync-resummary.test.ts
+++ b/test/sync-resummary.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, statSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock the summarizer so we control the body each sync produces and assert how
+// many times it runs. sync.ts loads the summarizer via `await import`, which
+// vi.mock intercepts as long as the mock is registered before sync is loaded.
+vi.mock('../src/summarizer.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/summarizer.js')>('../src/summarizer.js');
+  return {
+    ...actual,
+    summarizeConversation: vi.fn(),
+  };
+});
+
+import { syncConversations } from '../src/sync.js';
+import { summarizeConversation } from '../src/summarizer.js';
+import { isErroredSentinel, parseSummaryFile } from '../src/summary-sentinel.js';
+
+// Two exchanges with old timestamps so the conversation is quiescent immediately
+// (QUIESCENCE_HOURS=0 means any past timestamp qualifies).
+function makeJsonl(sessionId: string): string {
+  return [
+    JSON.stringify({
+      type: 'user',
+      uuid: `${sessionId}-user-1`,
+      parentUuid: null,
+      timestamp: '2025-10-01T12:00:00Z',
+      isSidechain: false,
+      cwd: '/tmp/test-cwd',
+      message: { role: 'user', content: 'What does the deploy script do?' },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      uuid: `${sessionId}-asst-1`,
+      parentUuid: `${sessionId}-user-1`,
+      timestamp: '2025-10-01T12:00:01Z',
+      isSidechain: false,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'It deploys to prod via terraform apply.' }] },
+    }),
+  ].join('\n');
+}
+
+// Two further exchanges appended to grow the transcript (strictly larger file).
+function makeGrowthJsonl(sessionId: string): string {
+  return [
+    '',
+    JSON.stringify({
+      type: 'user',
+      uuid: `${sessionId}-user-2`,
+      parentUuid: `${sessionId}-asst-1`,
+      timestamp: '2025-10-01T12:05:00Z',
+      isSidechain: false,
+      cwd: '/tmp/test-cwd',
+      message: { role: 'user', content: 'And how do we roll it back if it breaks?' },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      uuid: `${sessionId}-asst-2`,
+      parentUuid: `${sessionId}-user-2`,
+      timestamp: '2025-10-01T12:05:01Z',
+      isSidechain: false,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Run terraform apply against the previous state version.' }] },
+    }),
+  ].join('\n');
+}
+
+describe('sync command — self-healing (growth-driven) re-summary', () => {
+  let testDir: string;
+  let sourceDir: string;
+  let destDir: string;
+  const sessionId = '019aff97-5651-71e0-80ec-b4f2c51095c3';
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'episodic-memory-sync-resummary-test-'));
+    sourceDir = join(testDir, 'source');
+    destDir = join(testDir, 'dest');
+    mkdirSync(join(sourceDir, 'project-a'), { recursive: true });
+    vi.mocked(summarizeConversation).mockReset();
+    // Disable the quiescence gate (default 1h idle) so summaries are produced
+    // synchronously from fixtures during the test run.
+    process.env.EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS = '0';
+  });
+
+  afterEach(() => {
+    delete process.env.EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS;
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  const sourcePath = () => join(sourceDir, 'project-a', `${sessionId}.jsonl`);
+  const archiveJsonlPath = () => join(destDir, 'project-a', `${sessionId}.jsonl`);
+  const summaryPath = () => join(destDir, 'project-a', `${sessionId}-summary.txt`);
+
+  // copyIfNewer only re-copies when the source mtime is STRICTLY newer than the
+  // archive's. In a fast test the two writes can land in the same millisecond, so
+  // we force the source's mtime safely into the future to guarantee a re-copy.
+  function forceSourceNewer() {
+    const future = new Date(Date.now() + 10_000);
+    utimesSync(sourcePath(), future, future);
+  }
+
+  it('re-summarizes once a grown conversation is synced again', async () => {
+    // --- First sync: two exchanges, first summary. ---
+    writeFileSync(sourcePath(), makeJsonl(sessionId), 'utf-8');
+    vi.mocked(summarizeConversation).mockResolvedValue('First summary.');
+
+    const r1 = await syncConversations(sourceDir, destDir, { skipIndex: true });
+    expect(r1.summarized).toBe(1);
+    expect(existsSync(summaryPath())).toBe(true);
+
+    const first = parseSummaryFile(readFileSync(summaryPath(), 'utf-8'));
+    expect(first.body).toBe('First summary.');
+    // Coverage must equal the archived JSONL size so the file is NOT immediately re-queued.
+    const archiveBytes1 = statSync(archiveJsonlPath()).size;
+    expect(first.coverage?.bytes).toBe(archiveBytes1);
+
+    // --- Grow the source: append two more exchanges. ---
+    writeFileSync(sourcePath(), makeJsonl(sessionId) + makeGrowthJsonl(sessionId), 'utf-8');
+    const grownSourceBytes = statSync(sourcePath()).size;
+    expect(grownSourceBytes).toBeGreaterThan(archiveBytes1);
+    // Guarantee a re-copy despite same-millisecond mtimes.
+    forceSourceNewer();
+
+    vi.mocked(summarizeConversation).mockResolvedValue('Updated summary.');
+    const r2 = await syncConversations(sourceDir, destDir, { skipIndex: true });
+
+    // The archive must have actually grown (proves copyIfNewer re-copied).
+    const archiveBytes2 = statSync(archiveJsonlPath()).size;
+    expect(archiveBytes2).toBeGreaterThan(archiveBytes1);
+    expect(archiveBytes2).toBe(grownSourceBytes);
+
+    // Re-summary happened exactly once more, with the new body and larger coverage.
+    expect(vi.mocked(summarizeConversation).mock.calls.length).toBe(2);
+    expect(r2.summarized).toBe(1);
+    const second = parseSummaryFile(readFileSync(summaryPath(), 'utf-8'));
+    expect(second.body).toBe('Updated summary.');
+    expect(second.coverage?.bytes).toBe(archiveBytes2);
+    expect(second.coverage!.bytes).toBeGreaterThan(first.coverage!.bytes);
+  });
+
+  it('does not re-summarize an unchanged conversation on the next sync', async () => {
+    writeFileSync(sourcePath(), makeJsonl(sessionId), 'utf-8');
+    vi.mocked(summarizeConversation).mockResolvedValue('Stable summary.');
+
+    await syncConversations(sourceDir, destDir, { skipIndex: true });
+    expect(vi.mocked(summarizeConversation).mock.calls.length).toBe(1);
+    const before = readFileSync(summaryPath(), 'utf-8');
+
+    // Second sync with NO source change — nothing grew, so no re-summary.
+    const r2 = await syncConversations(sourceDir, destDir, { skipIndex: true });
+    expect(vi.mocked(summarizeConversation).mock.calls.length).toBe(1);
+    expect(r2.summarized).toBe(0);
+
+    const after = readFileSync(summaryPath(), 'utf-8');
+    expect(after).toBe(before);
+  });
+
+  it('preserves the prior summary when a re-summary fails', async () => {
+    // --- First sync: good summary. ---
+    writeFileSync(sourcePath(), makeJsonl(sessionId), 'utf-8');
+    vi.mocked(summarizeConversation).mockResolvedValue('Good summary.');
+    await syncConversations(sourceDir, destDir, { skipIndex: true });
+    expect(parseSummaryFile(readFileSync(summaryPath(), 'utf-8')).body).toBe('Good summary.');
+    const archiveBytes1 = statSync(archiveJsonlPath()).size;
+
+    // --- Grow the source so the file re-queues, then make re-summary fail. ---
+    writeFileSync(sourcePath(), makeJsonl(sessionId) + makeGrowthJsonl(sessionId), 'utf-8');
+    forceSourceNewer();
+    vi.mocked(summarizeConversation).mockRejectedValueOnce(new Error('Outage'));
+
+    const r2 = await syncConversations(sourceDir, destDir, { skipIndex: true });
+
+    // The archive grew (so a re-summary was genuinely attempted) and failed once.
+    expect(statSync(archiveJsonlPath()).size).toBeGreaterThan(archiveBytes1);
+    expect(vi.mocked(summarizeConversation).mock.calls.length).toBe(2);
+    expect(r2.errors.length).toBe(1);
+
+    // The prior real summary is preserved — NOT overwritten with an error sentinel.
+    const content = readFileSync(summaryPath(), 'utf-8');
+    expect(isErroredSentinel(content)).toBe(false);
+    expect(parseSummaryFile(content).body).toBe('Good summary.');
+  });
+});

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -23,10 +23,15 @@ describe('sync command', () => {
 
     // Set DB path for sync to use
     process.env.TEST_DB_PATH = dbPath;
+
+    // Summaries are gated on quiescence (default 1h idle). Disable the gate so
+    // these tests can exercise summary generation synchronously.
+    process.env.EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS = '0';
   });
 
   afterEach(() => {
     delete process.env.TEST_DB_PATH;
+    delete process.env.EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS;
     try {
       rmSync(testDir, { recursive: true, force: true });
     } catch (error) {

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -94,7 +94,7 @@ describe('verifyIndex', () => {
       JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'Hello' }, timestamp: '2024-01-01T00:00:01Z' })
     ];
     fs.writeFileSync(conversationPath, messages.join('\n'));
-    fs.writeFileSync(summaryPath, formatErrorSentinel(new Error('Transient outage')), 'utf-8');
+    fs.writeFileSync(summaryPath, formatErrorSentinel(new Error('Transient outage'), { attempts: 1, lastAttempt: Date.now() }), 'utf-8');
 
     const result = await verifyIndex();
     expect(result.missing.length).toBe(1);


### PR DESCRIPTION
## Description

Summaries are **write-once**. A conversation that gets summarized while still in
progress keeps a summary of only its early portion **forever** — every later turn
is invisible to the summary. For long-running or resumed conversations, the
one-line summary shown next to search results is therefore misleading.

The fix has two complementary halves: **defer** summarizing a conversation until
it has gone idle (so a still-active conversation is never frozen into a partial
snapshot), and **refresh** a summary when its transcript later grows. Note the
behavioral change from the defer half: a conversation is no longer summarized
until it has been idle for the quiescence window (`EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS`,
default 1h), so very recent conversations intentionally have no summary yet.

Because the refresh half makes us re-summarize, failures can now *recur* — so the
same change also makes failed (re-)summaries **back off and eventually give up**
instead of preserving a good summary but re-attempting on every sync. That retry
policy is unified with the existing first-failure error-sentinel path (see Fix 5).

(Search results themselves were always complete — search runs over indexed
*exchanges*, kept fresh via `INSERT OR REPLACE`. This fixes only the summary
displayed alongside them.)

## Symptom

There is no error in the logs — the symptom is silently wrong output, plus
silently wasted work:

- `<archive>/<project>/<session>-summary.txt` for an active or long conversation
  describes only the first handful of exchanges.
- Continuing the conversation over hours/days never updates it.
- `stats`/`verify` count the file as "summarized", so it is never revisited.
- A conversation that *can't* be summarized (oversized transcript, a turn that
  always errors) re-invokes the summarizer on every sync, indefinitely.

## Environment

- episodic-memory v1.4.2
- Claude Agent SDK summarizer
- All installs affected; most visible to anyone who keeps long or resumed
  sessions.

## Steps to Reproduce

1. Start a conversation and let a sync summarize it early (a few exchanges).
2. Continue the conversation for many more turns over time.
3. Run `sync` again (or let the SessionStart background sync run).
4. Inspect `<archive>/<project>/<session>-summary.txt`.
5. Observe it still summarizes only the early portion — never re-summarized,
   even though the transcript has grown substantially.

## Root Cause

`shouldQueueForSummary` only re-queued a conversation when its sentinel was
**missing** or a **stale error marker**. Once a real summary existed, the
conversation was treated as done permanently:

1. **No coverage signal.** Nothing recorded *how much* of the transcript a given
   summary reflected, so transcript growth was undetectable.
2. **Append-only transcripts.** A summary written at exchange 5 is never
   refreshed at exchange 500 — the file only ever grows, but nothing acted on
   that growth.
3. **No idle awareness.** Even if growth had been detected, summarizing an
   in-progress conversation would freeze a mid-session snapshot that is itself
   immediately stale.

And once re-summarization exists, a fourth gap appears in failure handling:

4. **Unbounded retries.** A failed re-summary correctly kept the prior summary
   but recorded nothing, so the file re-queued and re-invoked the LLM on *every*
   sync forever. First-ever failures (`#96` error sentinels) backed off ~1h but
   never gave up. And since sync is `SessionStart`-driven, not a fixed timer, a
   1h floor rarely even skips a sync — the retry effectively fired every sync.

## Fix Summary

1. **Coverage header.** Real summaries now carry a machine-readable first line —
   `__COVERAGE__ {"bytes":<n>,"lastExchange":"<iso>","schema":1}` — recording the
   archived JSONL byte size the summary reflects (`formatSummaryFile` /
   `parseSummaryFile`, `buildCoverage`, `writeSummary`).
2. **Growth-driven re-queue.** `shouldQueueForSummary(path, currentArchiveBytes)`
   re-queues a real summary when the archive has grown past its covered bytes
   (append-only ⇒ a size increase means new content).
3. **Quiescence gate.** `isQuiescent` + `EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS`
   (default `1`) only (re)summarize after the conversation has been idle for the
   window, so a mid-session snapshot is never frozen. Idle is measured from the
   **last exchange's timestamp** — the archive copy's mtime is reset on every
   sync and is unreliable.
4. **Gentle upgrade.** Legacy header-less summaries are stamped with a
   current-size baseline (`ensureCoverageBaseline`) — a header rewrite, **no LLM
   call** — so existing installs gain a growth baseline without a mass
   re-summarization on upgrade.
5. **Preserve, back off, then give up on failure.** A failed (re-)summary keeps
   any prior real summary and records the attempt; one shared policy
   (`shouldRetryAfterFailure`) then holds the file until the retry floor
   (`EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS`, default 1h) elapses and abandons
   it after `EPISODIC_MEMORY_SUMMARY_MAX_ATTEMPTS` (default 5) — keeping the last
   good summary rather than thrashing. This same policy governs **both** first-ever
   failures (`#96` error sentinels, now attempt-counted) and re-summary failures
   (state in the coverage header's `resummary` field), via `recordSummaryFailure`.
   It replaces the prior mtime-based, never-give-up retry and the duplicated
   floor/cap logic.
6. **Fair queue ordering.** Never-summarized conversations are processed ahead of
   re-summary retries before the per-run `summaryLimit`, so a backlog of failing
   re-summaries can't starve fresh work (the `#91` head-of-queue failure mode).
7. **Display.** `search` strips the coverage header from the summary shown
   alongside results.

Internally, the gate + write + failure logic is shared (`needsSummary`,
`recordSummaryFailure`, `shouldRetryAfterFailure`, `summarizeIfQuiescent`) across
the three indexer paths and the sync loop, and the `_HOURS` config defaults
convert to milliseconds at a single boundary (`MS_PER_HOUR`).

## Configuration

- `EPISODIC_MEMORY_SUMMARY_QUIESCENCE_HOURS` (default `1`) — idle time before a
  conversation is (re)summarized.
- `EPISODIC_MEMORY_SUMMARY_ERROR_RETRY_HOURS` (default `1`) — minimum wait between
  failed summary attempts (the retry floor).
- `EPISODIC_MEMORY_SUMMARY_MAX_ATTEMPTS` (default `5`) — failed attempts before
  giving up and keeping any existing summary. **(new)**

## Error-sentinel format change

The `#96` error sentinel's second line changes from a bare ISO timestamp to a
JSON failure-state line, so it can carry the attempt count:

```
before:  __ERRORED__\n2026-06-07T10:00:00.000Z\n<message>
after:   __ERRORED__\n{"attempts":2,"lastAttempt":1718040000000}\n<message>
```

Backward compatible: `parseErrorSentinel` reads the legacy v1.4.2 ISO form
(→ `attempts: 0`, `lastAttempt` from the timestamp), so sentinels already on disk
keep backing off correctly and are rewritten in the new form on their next
failure. An unrecognised second line degrades safely to `{attempts: 0,
lastAttempt: 0}` → retried, never lost.

## Tests added

- `test/summary-coverage.test.ts` — coverage header round-trip and legacy baseline stamping.
- `test/summary-quiescence.test.ts` — quiescence verdicts and `_HOURS` env parsing.
- `test/summary-sentinel.test.ts` — growth-aware gate decision table; unified
  backoff/give-up for both error sentinels and re-summaries; `parseErrorSentinel`
  round-trip + legacy ISO fallback; `getMaxSummaryAttempts`; `recordSummaryFailure`.
- `test/summary-queue-order.test.ts` — fresh-before-retry ordering (`#91` guard).
- `test/sync-resummary.test.ts` — growth-driven re-summary, no-op when unchanged,
  preserve-on-failure (now also asserts the attempt is recorded).
- `test/search-summary-strip.test.ts` — the header never leaks into the displayed summary.
- Updates to `sync-error-sentinel` (mtime-aging → stored-timestamp; sentinel-format
  assertion), `show`, and `sync` tests for the new header/gate.

## Fix Verified

- **Full suite:** 258 tests across 41 files pass.
- **Real end-to-end** on the built `dist` (isolated temp dirs, real summarizer):
  - Seed an 8 237-byte conversation → first sync writes a summary stamped `"bytes":8237`.
  - Grow the transcript to 41 069 bytes → next sync re-summarizes; coverage re-stamped `"bytes":41069`.
  - No further growth → next sync performs no re-summary.

## Caveat / Notes

- Re-summary is triggered by **byte growth**, not an exchange-count delta. This
  is deliberate: transcripts are append-only and the per-sync coverage scan is
  ~23 ms even against a multi-GB archive, so no recency cutoff or minimum-delta
  threshold is needed. The quiescence gate bounds work to one re-summary per
  idle-after-growth episode.
- Give-up is **permanent** for a given conversation (it keeps its last good
  summary, if any): the attempt cap bounds cost on a transcript that never
  summarizes. The cap is the real bound, since the coarse, variable sync cadence
  makes the wall-clock floor too short to reliably skip a sync; the floor's job
  is to stop rapid session restarts from spending the budget on a transient blip.
