### PR TITLE
fix(summarizer): summarize conversations that end on an extended-thinking turn

### DIFF
--- a/dist/summarizer.d.ts
+++ b/dist/summarizer.d.ts
@@ -1,17 +1,26 @@
 import { ConversationExchange } from './types.js';
 /**
- * Thrown by callClaude when the SDK yields an `is_error: true` result message.
- * Carries the SDK's `subtype` and `session_id` as typed fields so callers can
- * dispatch on structural metadata rather than parsing error message text.
+ * Thrown by callClaude on an `is_error: true` result. Carries `subtype`,
+ * `session_id`, `api_error_status`, and the error text so callers can dispatch
+ * on structure and logs show the real failure, not a bare subtype. The SDK
+ * pairs `subtype: 'success'` with `is_error: true` when the loop finished but
+ * the turn hit an API error (carried in `result` / `api_error_status`).
  */
 export declare class SummarizerSdkError extends Error {
     readonly subtype: string;
     readonly sessionId?: string | undefined;
-    constructor(subtype: string, sessionId?: string | undefined);
+    readonly apiErrorStatus?: number | null | undefined;
+    readonly apiError?: string | undefined;
+    constructor(subtype: string, sessionId?: string | undefined, apiErrorStatus?: number | null | undefined, apiError?: string | undefined);
 }
 /**
- * True when the SDK's reported failure subtype indicates resume couldn't find
- * the session — the trigger for the non-resume fallback in summarizeConversation.
+ * True when the resume continuation itself failed — the trigger for the
+ * non-resume fallback in summarizeConversation. Two signals:
+ * - `error_during_execution`: the SDK couldn't resume (e.g. recorded cwd gone).
+ * - HTTP 400: the API rejected the replayed history, canonically `thinking`
+ *   blocks it forbids modifying on continuation. Our prompt is plain text, so a
+ *   400 on resume can only come from the replayed turns. Other statuses aren't
+ *   resume-specific and propagate.
  */
 export declare function isResumeFailure(error: unknown): boolean;
 export interface CodexSummarizerCommand {

--- a/dist/summarizer.js
+++ b/dist/summarizer.js
@@ -6,26 +6,48 @@ import { spawn } from 'child_process';
 import { createInterface } from 'readline';
 import { codexVersionRequirementMessage, parseCodexCliVersion, versionMeetsMinimum, } from './codex-support.js';
 /**
- * Thrown by callClaude when the SDK yields an `is_error: true` result message.
- * Carries the SDK's `subtype` and `session_id` as typed fields so callers can
- * dispatch on structural metadata rather than parsing error message text.
+ * Thrown by callClaude on an `is_error: true` result. Carries `subtype`,
+ * `session_id`, `api_error_status`, and the error text so callers can dispatch
+ * on structure and logs show the real failure, not a bare subtype. The SDK
+ * pairs `subtype: 'success'` with `is_error: true` when the loop finished but
+ * the turn hit an API error (carried in `result` / `api_error_status`).
  */
 export class SummarizerSdkError extends Error {
     subtype;
     sessionId;
-    constructor(subtype, sessionId) {
-        super(`Summarizer SDK error: ${subtype}${sessionId ? ` (session ${sessionId})` : ''}`);
+    apiErrorStatus;
+    apiError;
+    constructor(subtype, sessionId, apiErrorStatus, apiError) {
+        let message = `Summarizer SDK error: ${subtype}`;
+        if (apiErrorStatus != null)
+            message += ` (HTTP ${apiErrorStatus})`;
+        if (sessionId)
+            message += ` (session ${sessionId})`;
+        if (apiError)
+            message += `: ${apiError}`;
+        super(message);
         this.subtype = subtype;
         this.sessionId = sessionId;
+        this.apiErrorStatus = apiErrorStatus;
+        this.apiError = apiError;
         this.name = 'SummarizerSdkError';
     }
 }
 /**
- * True when the SDK's reported failure subtype indicates resume couldn't find
- * the session — the trigger for the non-resume fallback in summarizeConversation.
+ * True when the resume continuation itself failed — the trigger for the
+ * non-resume fallback in summarizeConversation. Two signals:
+ * - `error_during_execution`: the SDK couldn't resume (e.g. recorded cwd gone).
+ * - HTTP 400: the API rejected the replayed history, canonically `thinking`
+ *   blocks it forbids modifying on continuation. Our prompt is plain text, so a
+ *   400 on resume can only come from the replayed turns. Other statuses aren't
+ *   resume-specific and propagate.
  */
 export function isResumeFailure(error) {
-    return error instanceof SummarizerSdkError && error.subtype === 'error_during_execution';
+    if (!(error instanceof SummarizerSdkError))
+        return false;
+    if (error.subtype === 'error_during_execution')
+        return true;
+    return error.apiErrorStatus === 400;
 }
 /**
  * Get API environment overrides for summarization calls.
@@ -146,11 +168,12 @@ async function callClaude(prompt, sessionId, useFallback = false, cwd) {
         options: buildSummarizerQueryOptions({ model, sessionId, cwd }),
     })) {
         if (message && typeof message === 'object' && 'type' in message && message.type === 'result') {
-            // Throw on is_error — otherwise we return `message.result` (undefined) and the SDK's later iterator throw never fires.
-            if (message.is_error) {
-                throw new SummarizerSdkError(message.subtype || 'unknown', message.session_id);
-            }
             const result = message.result;
+            // Throw on is_error, carrying the API error text + status so logs are
+            // diagnostic and summarizeConversation can route a 400 to the non-resume fallback.
+            if (message.is_error) {
+                throw new SummarizerSdkError(message.subtype || 'unknown', message.session_id, message.api_error_status, typeof result === 'string' ? result : undefined);
+            }
             // Check if result is an API error (SDK returns errors as result strings)
             if (typeof result === 'string' && result.includes('API Error') && result.includes('thinking.budget_tokens')) {
                 if (!useFallback) {

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -12,23 +12,41 @@ import {
 } from './codex-support.js';
 
 /**
- * Thrown by callClaude when the SDK yields an `is_error: true` result message.
- * Carries the SDK's `subtype` and `session_id` as typed fields so callers can
- * dispatch on structural metadata rather than parsing error message text.
+ * Thrown by callClaude on an `is_error: true` result. Carries `subtype`,
+ * `session_id`, `api_error_status`, and the error text so callers can dispatch
+ * on structure and logs show the real failure, not a bare subtype. The SDK
+ * pairs `subtype: 'success'` with `is_error: true` when the loop finished but
+ * the turn hit an API error (carried in `result` / `api_error_status`).
  */
 export class SummarizerSdkError extends Error {
-  constructor(public readonly subtype: string, public readonly sessionId?: string) {
-    super(`Summarizer SDK error: ${subtype}${sessionId ? ` (session ${sessionId})` : ''}`);
+  constructor(
+    public readonly subtype: string,
+    public readonly sessionId?: string,
+    public readonly apiErrorStatus?: number | null,
+    public readonly apiError?: string,
+  ) {
+    let message = `Summarizer SDK error: ${subtype}`;
+    if (apiErrorStatus != null) message += ` (HTTP ${apiErrorStatus})`;
+    if (sessionId) message += ` (session ${sessionId})`;
+    if (apiError) message += `: ${apiError}`;
+    super(message);
     this.name = 'SummarizerSdkError';
   }
 }
 
 /**
- * True when the SDK's reported failure subtype indicates resume couldn't find
- * the session — the trigger for the non-resume fallback in summarizeConversation.
+ * True when the resume continuation itself failed — the trigger for the
+ * non-resume fallback in summarizeConversation. Two signals:
+ * - `error_during_execution`: the SDK couldn't resume (e.g. recorded cwd gone).
+ * - HTTP 400: the API rejected the replayed history, canonically `thinking`
+ *   blocks it forbids modifying on continuation. Our prompt is plain text, so a
+ *   400 on resume can only come from the replayed turns. Other statuses aren't
+ *   resume-specific and propagate.
  */
 export function isResumeFailure(error: unknown): boolean {
-  return error instanceof SummarizerSdkError && error.subtype === 'error_during_execution';
+  if (!(error instanceof SummarizerSdkError)) return false;
+  if (error.subtype === 'error_during_execution') return true;
+  return error.apiErrorStatus === 400;
 }
 
 export interface CodexSummarizerCommand {
@@ -179,11 +197,18 @@ async function callClaude(prompt: string, sessionId?: string, useFallback = fals
     options: buildSummarizerQueryOptions({ model, sessionId, cwd }) as any,
   })) {
     if (message && typeof message === 'object' && 'type' in message && message.type === 'result') {
-      // Throw on is_error — otherwise we return `message.result` (undefined) and the SDK's later iterator throw never fires.
-      if ((message as any).is_error) {
-        throw new SummarizerSdkError((message as any).subtype || 'unknown', (message as any).session_id);
-      }
       const result = (message as any).result;
+
+      // Throw on is_error, carrying the API error text + status so logs are
+      // diagnostic and summarizeConversation can route a 400 to the non-resume fallback.
+      if ((message as any).is_error) {
+        throw new SummarizerSdkError(
+          (message as any).subtype || 'unknown',
+          (message as any).session_id,
+          (message as any).api_error_status,
+          typeof result === 'string' ? result : undefined,
+        );
+      }
 
       // Check if result is an API error (SDK returns errors as result strings)
       if (typeof result === 'string' && result.includes('API Error') && result.includes('thinking.budget_tokens')) {

--- a/test/show.test.ts
+++ b/test/show.test.ts
@@ -182,8 +182,8 @@ describe('show command - markdown formatting', () => {
     expect(markdown).toMatch(/\*\*Agent\*\*/);
     expect(markdown).toContain('Looking at your instructions');
 
-    // Should show timestamps
-    expect(markdown).toMatch(/9\/19\/2025|2025-09-19/);
+    const expectedTimestamp = new Date('2025-09-19T17:34:29.181Z').toLocaleString();
+    expect(markdown).toContain(expectedTimestamp);
   });
 
   it('should include tool calls in the output', () => {

--- a/test/summarizer-options.test.ts
+++ b/test/summarizer-options.test.ts
@@ -76,12 +76,64 @@ describe('isResumeFailure', () => {
     expect(isResumeFailure(new SummarizerSdkError('unknown'))).toBe(false);
   });
 
+  it('matches an is_error result carrying HTTP 400 — the API rejecting the replayed thinking blocks on resume', () => {
+    // 'success' subtype but the turn hit a 400 — the thinking-block rejection.
+    const thinkingBlock400 = new SummarizerSdkError(
+      'success',
+      'abc-123',
+      400,
+      'API Error: 400 messages.1.content.25: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.',
+    );
+    expect(isResumeFailure(thinkingBlock400)).toBe(true);
+  });
+
+  it('does not match non-400 HTTP statuses — auth/rate-limit/server errors are not resume-specific', () => {
+    // Retrying without resume wouldn't help these, so they propagate.
+    expect(isResumeFailure(new SummarizerSdkError('success', 'abc-123', 401, 'API Error: 401'))).toBe(false);
+    expect(isResumeFailure(new SummarizerSdkError('success', 'abc-123', 429, 'API Error: 429'))).toBe(false);
+    expect(isResumeFailure(new SummarizerSdkError('success', 'abc-123', 529, 'API Error: 529'))).toBe(false);
+  });
+
   it('does not match plain Error or non-Error values, even if their text looks resume-related', () => {
     expect(isResumeFailure(new Error('No conversation found with session ID: abc'))).toBe(false);
     expect(isResumeFailure(new Error('error_during_execution'))).toBe(false);
     expect(isResumeFailure('No conversation found')).toBe(false);
     expect(isResumeFailure(undefined)).toBe(false);
     expect(isResumeFailure(null)).toBe(false);
+  });
+});
+
+describe('SummarizerSdkError', () => {
+  it('exposes subtype, sessionId, apiErrorStatus, and the API error text as typed fields', () => {
+    const error = new SummarizerSdkError(
+      'success',
+      'sess-1',
+      400,
+      'API Error: 400 messages.1.content.25: `thinking` blocks cannot be modified.',
+    );
+    expect(error.subtype).toBe('success');
+    expect(error.sessionId).toBe('sess-1');
+    expect(error.apiErrorStatus).toBe(400);
+    expect(error.apiError).toContain('thinking');
+  });
+
+  it('builds a diagnostic message that surfaces the real API error instead of a bare subtype', () => {
+    const error = new SummarizerSdkError(
+      'success',
+      'sess-1',
+      400,
+      'API Error: 400 messages.1.content.25: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified.',
+    );
+    // The pre-fix message was the useless "Summarizer SDK error: success".
+    expect(error.message).not.toBe('Summarizer SDK error: success');
+    expect(error.message).toContain('400');
+    expect(error.message).toContain('cannot be modified');
+  });
+
+  it('still renders a compact message when no API error detail is present', () => {
+    const error = new SummarizerSdkError('error_during_execution', 'sess-2');
+    expect(error.message).toContain('error_during_execution');
+    expect(error.message).toContain('sess-2');
   });
 });
 

--- a/test/summarizer-resume-fallback.test.ts
+++ b/test/summarizer-resume-fallback.test.ts
@@ -152,4 +152,35 @@ describe('summarizeConversation — Claude resume fallback (cwd-mismatch recover
       .rejects.toBeInstanceOf(SummarizerSdkError);
     expect(vi.mocked(query)).toHaveBeenCalledTimes(1);
   });
+
+  it('falls back to the non-resume path when resume hits the thinking-block 400, returning the recovered summary', async () => {
+    // Resume replays immutable thinking blocks → 400 (subtype 'success',
+    // is_error true). The non-resume path retries with the transcript as text.
+    vi.mocked(query)
+      .mockReturnValueOnce(asyncIterableFor([
+        {
+          type: 'result',
+          subtype: 'success',
+          is_error: true,
+          api_error_status: 400,
+          session_id: 'abc-123',
+          result: 'API Error: 400 messages.1.content.25: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.',
+        },
+      ]) as any)
+      .mockReturnValueOnce(asyncIterableFor([
+        { type: 'result', is_error: false, result: '<summary>Summary recovered via transcript fallback.</summary>' },
+      ]) as any);
+
+    const result = await summarizeConversation([makeExchange()], 'abc-123');
+    expect(result).toBe('Summary recovered via transcript fallback.');
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(2);
+
+    const firstCallOptions = vi.mocked(query).mock.calls[0][0].options as any;
+    expect(firstCallOptions.resume).toBe('abc-123');
+
+    const secondCallOptions = vi.mocked(query).mock.calls[1][0].options as any;
+    expect(secondCallOptions.resume).toBeUndefined();
+    const secondPrompt = vi.mocked(query).mock.calls[1][0].prompt as string;
+    expect(secondPrompt).toContain('How do I rebase against origin/main?');
+  });
 });


### PR DESCRIPTION
# Summarizer fails permanently on conversations whose last assistant turn used extended thinking

## Description

To summarize a short conversation (≤15 exchanges) the summarizer **resumes the session** via the Claude Agent SDK and asks for a `<summary>`. If that session's latest assistant message contains `thinking` / `redacted_thinking` blocks (extended thinking was on), resume replays that turn and the API rejects the continuation with a deterministic **400** — those blocks "cannot be modified". The conversation is written an error sentinel and retried, identically, on every sync forever — re-parsing a ~600 KB transcript and re-spawning a Claude subprocess each cycle.

Log fingerprint:

```
⚠️  Errors: 1
  <archive>/<uuid>.jsonl:
    Summary generation failed: Summarizer SDK error: success (session <uuid>)
```

`success` is misleading: the SDK reports this as an `SDKResultSuccess` with `subtype: 'success'` but `is_error: true`, `api_error_status: 400`, and the real message in `result`. The code discarded all of that and logged only the meaningless subtype.

Isolated but real: in an archive of 2,129 summaries this was the *only* errored conversation — the one that both ended on a thinking-block turn and was short enough (6 exchanges) to take the resume path. Size is not the cause; 500 MB+ transcripts summarize fine via the non-resume hierarchical path.

## Environment

- episodic-memory v1.4.2
- `@anthropic-ai/claude-agent-sdk` bundled with v1.4.2

## Root Cause

The Anthropic API constraint is the trigger; two code defects turn a recoverable condition into a permanent, opaque failure.

**1. `callClaude` throws away the real error.** It built `SummarizerSdkError` from only `subtype`, discarding `message.result` (`"API Error: 400 … thinking blocks … cannot be modified"`) and `api_error_status` (`400`). `subtype: 'success'` + `is_error: true` is a documented `SDKResultSuccess` combination — the agent loop finished, but the turn hit an API error.

**2. The non-resume fallback never fired.** `isResumeFailure` matched only `subtype === 'error_during_execution'`. This case is `'success'`, so no fallback ran and the error propagated to a sentinel. The non-resume path would summarize it fine — it never replays the thinking blocks.

Reproduced (resume the offending session, logging the raw result):

```json
{ "subtype": "success", "is_error": true, "api_error_status": 400, "num_turns": 1,
  "result": "API Error: 400 messages.1.content.25: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. ..." }
```

## Fix Summary

Two parts; see the diff for code.

1. **Surface the real error.** `SummarizerSdkError` now carries `apiErrorStatus` and the API error text and renders them in the message, so the log shows the actual 400 instead of `success`.
2. **Broaden the non-resume fallback.** `isResumeFailure` now also treats an HTTP **400** on a resume call as a resume failure. Our summary prompt is plain, well-formed text, so a 400 there can only come from the replayed history; the non-resume path (fresh session, transcript as text) sidesteps the immutable thinking blocks. Non-resume statuses (401/403/429/5xx) still propagate without a futile retry.

Tests added: `test/summarizer-options.test.ts` (unit coverage for the broadened `isResumeFailure` and the diagnostic `SummarizerSdkError` fields/message) and `test/summarizer-resume-fallback.test.ts` (integration via a mocked SDK — the thinking-block 400 reproduced exactly, and recovery through the non-resume path).

## Fix Verified

Full suite passes (213/213). The integration test reproduces the exact SDK result shape from the real failure (`subtype: 'success'`, `is_error: true`, `api_error_status: 400`) and asserts the summary is recovered via the non-resume retry. Validated end-to-end against the original failing session (`fd2f1897`) on `claude-agent-sdk` 0.2.141: the resume reproduces the 400 as that exact result shape, `SummarizerSdkError` surfaces it, `isResumeFailure` routes it, and the non-resume fallback returns a correct summary. The diagnostic log now reads:

```
resume failed for <uuid> (Summarizer SDK error: success (HTTP 400) (session <uuid>): API Error: 400 … `thinking` … cannot be modified …); retrying without resume
```

Also in this PR: `test(show)` makes a timestamp assertion locale/timezone-independent — a pre-existing failure on a clean checkout under non-US locales (the assertion hardcoded a US/ISO date regex), unrelated to the summarizer but required to get the suite green.