### PR TITLE
perf: skip copying and indexing sidechain conversations to reduce disk usage

### DIFF
--- a/dist/indexer.d.ts
+++ b/dist/indexer.d.ts
@@ -1,3 +1,16 @@
+import { initDatabase } from './db.js';
+import { ConversationExchange } from './types.js';
+/**
+ * Embed and insert exchanges, skipping sidechains (subagent dispatches, Warmup
+ * stubs, prompt-suggestion sidechains). Search excludes them via
+ * `AND is_sidechain = 0`, so indexing them would embed and store rows no query
+ * can ever return. Returns the number of exchanges actually inserted.
+ *
+ * This is the single place that decides what gets indexed — every indexing
+ * path (full reindex, single session, unprocessed backlog, background sync,
+ * verify/repair) routes through here so the sidechain filter can't be missed.
+ */
+export declare function indexExchanges(db: ReturnType<typeof initDatabase>, exchanges: ConversationExchange[]): Promise<number>;
 export declare function indexConversations(limitToProject?: string, maxConversations?: number, concurrency?: number, noSummaries?: boolean): Promise<void>;
 export declare function indexSession(sessionId: string, concurrency?: number, noSummaries?: boolean): Promise<void>;
 export declare function indexUnprocessed(concurrency?: number, noSummaries?: boolean): Promise<void>;

--- a/dist/indexer.js
+++ b/dist/indexer.js
@@ -24,6 +24,28 @@ async function processBatch(items, processor, concurrency) {
 function sessionIdForSummary(exchanges) {
     return exchanges.find(exchange => exchange.sessionId)?.sessionId;
 }
+/**
+ * Embed and insert exchanges, skipping sidechains (subagent dispatches, Warmup
+ * stubs, prompt-suggestion sidechains). Search excludes them via
+ * `AND is_sidechain = 0`, so indexing them would embed and store rows no query
+ * can ever return. Returns the number of exchanges actually inserted.
+ *
+ * This is the single place that decides what gets indexed — every indexing
+ * path (full reindex, single session, unprocessed backlog, background sync,
+ * verify/repair) routes through here so the sidechain filter can't be missed.
+ */
+export async function indexExchanges(db, exchanges) {
+    let inserted = 0;
+    for (const exchange of exchanges) {
+        if (exchange.isSidechain)
+            continue;
+        const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
+        const embedding = await generateExchangeEmbedding(exchange.userMessage, exchange.assistantMessage, toolNames);
+        insertExchange(db, exchange, embedding, toolNames);
+        inserted++;
+    }
+    return inserted;
+}
 export async function indexConversations(limitToProject, maxConversations, concurrency = 1, noSummaries = false) {
     console.log('Initializing database...');
     const db = initDatabase();
@@ -117,12 +139,7 @@ export async function indexConversations(limitToProject, maxConversations, concu
             }
             // Now process embeddings and DB inserts (fast, sequential is fine)
             for (const conv of toProcess) {
-                for (const exchange of conv.exchanges) {
-                    const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-                    const embedding = await generateExchangeEmbedding(exchange.userMessage, exchange.assistantMessage, toolNames);
-                    insertExchange(db, exchange, embedding, toolNames);
-                }
-                totalExchanges += conv.exchanges.length;
+                totalExchanges += await indexExchanges(db, conv.exchanges);
                 conversationsProcessed++;
                 // Check if we hit the limit
                 if (maxConversations && conversationsProcessed >= maxConversations) {
@@ -170,7 +187,8 @@ export async function indexSession(sessionId, concurrency = 1, noSummaries = fal
                 }
                 // Parse and summarize
                 const exchanges = await parseConversation(sourcePath, project, archivePath);
-                if (exchanges.length > 0) {
+                const indexable = exchanges.filter(e => !e.isSidechain);
+                if (indexable.length > 0) {
                     // Generate summary (unless --no-summaries)
                     const summaryPath = archivePath.replace('.jsonl', '-summary.txt');
                     if (!noSummaries && shouldQueueForSummary(summaryPath)) {
@@ -189,13 +207,8 @@ export async function indexSession(sessionId, concurrency = 1, noSummaries = fal
                             console.log(`Summary failed: ${error instanceof Error ? error.message : String(error)}`);
                         }
                     }
-                    // Index
-                    for (const exchange of exchanges) {
-                        const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-                        const embedding = await generateExchangeEmbedding(exchange.userMessage, exchange.assistantMessage, toolNames);
-                        insertExchange(db, exchange, embedding, toolNames);
-                    }
-                    console.log(`✅ Indexed session ${sessionId}: ${exchanges.length} exchanges`);
+                    const inserted = await indexExchanges(db, exchanges);
+                    console.log(`✅ Indexed session ${sessionId}: ${inserted} exchanges`);
                 }
                 db.close();
                 break;
@@ -294,11 +307,7 @@ export async function indexUnprocessed(concurrency = 1, noSummaries = false) {
     // Now index embeddings
     console.log(`\nIndexing embeddings...`);
     for (const conv of unprocessed) {
-        for (const exchange of conv.exchanges) {
-            const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-            const embedding = await generateExchangeEmbedding(exchange.userMessage, exchange.assistantMessage, toolNames);
-            insertExchange(db, exchange, embedding, toolNames);
-        }
+        await indexExchanges(db, conv.exchanges);
     }
     db.close();
     console.log(`\n✅ Processed ${unprocessed.length} conversations`);

--- a/dist/sync.d.ts
+++ b/dist/sync.d.ts
@@ -1,3 +1,15 @@
+/**
+ * Peek at the first ~8KB of a JSONL file and return whether the conversation
+ * is a sidechain. A file is "sidechain" when the first record carrying an
+ * isSidechain field has it set to true — subagent dispatches (every record),
+ * Warmup stubs, prompt-suggestion sidechains, ai-title stubs, etc.
+ *
+ * Conservative: if we can't read the file, can't parse a record, or no record
+ * carries the field within the scan cap, return false so the file is copied.
+ * Mixed-content sessions (regular session with some sidechain records inline)
+ * also return false — the indexer-side filter handles per-exchange skipping.
+ */
+export declare function isSidechainFile(filePath: string): boolean;
 export interface SyncResult {
     copied: number;
     skipped: number;

--- a/dist/sync.js
+++ b/dist/sync.js
@@ -18,25 +18,88 @@ function shouldSkipConversation(filePath) {
         return false;
     }
 }
-function copyIfNewer(src, dest) {
+/**
+ * Return whether a JSONL conversation file is a sidechain. A file is
+ * "sidechain" when the first record carrying an isSidechain field has it set to
+ * true — subagent dispatches (every record), Warmup stubs, prompt-suggestion
+ * sidechains, ai-title stubs, etc.
+ *
+ * Conservative: if we can't read the file, can't parse a record, or no record
+ * carries the field within the scan cap, return false so the file is copied.
+ * Mixed-content sessions (regular session with some sidechain records inline)
+ * also return false — the indexer-side filter handles per-exchange skipping.
+ */
+export function isSidechainFile(filePath) {
+    // Read in chunks and parse only complete (newline-terminated) records, so a
+    // first record larger than one chunk — e.g. a big opening prompt with
+    // attachments — is classified rather than truncated. Bounded so a
+    // pathologically large file is never read in full.
+    const CHUNK = 16384;
+    const MAX_BYTES = 1024 * 1024;
+    let fd = null;
+    try {
+        fd = fs.openSync(filePath, 'r');
+        const chunk = Buffer.alloc(CHUNK);
+        let pending = Buffer.alloc(0);
+        let pos = 0;
+        while (pos < MAX_BYTES) {
+            const bytesRead = fs.readSync(fd, chunk, 0, CHUNK, pos);
+            const atEof = bytesRead === 0;
+            if (!atEof) {
+                pos += bytesRead;
+                pending = Buffer.concat([pending, chunk.subarray(0, bytesRead)]);
+            }
+            // Parse each complete line; at EOF the trailing bytes are the final line.
+            let nl;
+            while ((nl = pending.indexOf(0x0a)) !== -1 || (atEof && pending.length > 0)) {
+                const line = nl !== -1 ? pending.subarray(0, nl) : pending;
+                pending = nl !== -1 ? pending.subarray(nl + 1) : Buffer.alloc(0);
+                if (line.length === 0)
+                    continue;
+                let parsed;
+                try {
+                    parsed = JSON.parse(line.toString('utf-8'));
+                }
+                catch {
+                    // A complete line that won't parse is malformed — stop, copy the file.
+                    return false;
+                }
+                if (typeof parsed?.isSidechain === 'boolean') {
+                    return parsed.isSidechain;
+                }
+            }
+            if (atEof)
+                break;
+        }
+        return false;
+    }
+    catch {
+        return false;
+    }
+    finally {
+        if (fd !== null) {
+            try {
+                fs.closeSync(fd);
+            }
+            catch { /* best-effort close */ }
+        }
+    }
+}
+function destIsUpToDate(src, dest) {
+    if (!fs.existsSync(dest))
+        return false;
+    return fs.statSync(dest).mtimeMs >= fs.statSync(src).mtimeMs;
+}
+function copyConversation(src, dest) {
     // Ensure destination directory exists
     const destDir = path.dirname(dest);
     if (!fs.existsSync(destDir)) {
         fs.mkdirSync(destDir, { recursive: true });
     }
-    // Check if destination exists and is up-to-date
-    if (fs.existsSync(dest)) {
-        const srcStat = fs.statSync(src);
-        const destStat = fs.statSync(dest);
-        if (destStat.mtimeMs >= srcStat.mtimeMs) {
-            return false; // Dest is current, skip
-        }
-    }
     // Atomic copy: temp file + rename
     const tempDest = dest + '.tmp.' + process.pid;
     fs.copyFileSync(src, tempDest);
     fs.renameSync(tempDest, dest); // Atomic on same filesystem
-    return true;
 }
 export function extractSessionIdFromPath(filePath) {
     // Extract session ID from Claude filename or Codex rollout filename.
@@ -81,13 +144,20 @@ export async function syncConversations(sourceDir, destDir, options = {}) {
             const srcFile = path.join(projectPath, file);
             const destFile = path.join(destDir, project, file);
             try {
-                const wasCopied = copyIfNewer(srcFile, destFile);
-                if (wasCopied) {
-                    result.copied++;
-                    filesToIndex.push(destFile);
+                // Cheap mtime gate first; only peek inside files we'd actually copy,
+                // so unchanged files aren't re-read on every sync.
+                if (destIsUpToDate(srcFile, destFile)) {
+                    result.skipped++;
+                }
+                else if (isSidechainFile(srcFile)) {
+                    // Sidechain files are never copied, indexed, or summarized.
+                    result.skipped++;
+                    continue;
                 }
                 else {
-                    result.skipped++;
+                    copyConversation(srcFile, destFile);
+                    result.copied++;
+                    filesToIndex.push(destFile);
                 }
                 // Check if this file needs a summary (whether newly copied or existing).
                 // shouldQueueForSummary skips files that already have a real summary or
@@ -112,9 +182,10 @@ export async function syncConversations(sourceDir, destDir, options = {}) {
     }
     // Index copied files (unless skipIndex is set)
     if (!options.skipIndex && filesToIndex.length > 0) {
-        const { initDatabase, insertExchange } = await import('./db.js');
-        const { initEmbeddings, generateExchangeEmbedding } = await import('./embeddings.js');
+        const { initDatabase } = await import('./db.js');
+        const { initEmbeddings } = await import('./embeddings.js');
         const { parseConversation } = await import('./parser.js');
+        const { indexExchanges } = await import('./indexer.js');
         const db = initDatabase();
         await initEmbeddings();
         for (const file of filesToIndex) {
@@ -125,11 +196,7 @@ export async function syncConversations(sourceDir, destDir, options = {}) {
                 }
                 const project = path.basename(path.dirname(file));
                 const exchanges = await parseConversation(file, project, file);
-                for (const exchange of exchanges) {
-                    const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-                    const embedding = await generateExchangeEmbedding(exchange.userMessage, exchange.assistantMessage, toolNames);
-                    insertExchange(db, exchange, embedding, toolNames);
-                }
+                await indexExchanges(db, exchanges);
                 result.indexed++;
             }
             catch (error) {

--- a/dist/verify.js
+++ b/dist/verify.js
@@ -94,10 +94,11 @@ export async function verifyIndex() {
 export async function repairIndex(issues) {
     console.log('Repairing index...');
     // To avoid circular dependencies, we import the indexer functions dynamically
-    const { initDatabase, insertExchange, deleteExchange } = await import('./db.js');
+    const { initDatabase, deleteExchange } = await import('./db.js');
     const { parseConversation } = await import('./parser.js');
-    const { initEmbeddings, generateExchangeEmbedding } = await import('./embeddings.js');
+    const { initEmbeddings } = await import('./embeddings.js');
     const { summarizeConversation } = await import('./summarizer.js');
+    const { indexExchanges } = await import('./indexer.js');
     const db = initDatabase();
     await initEmbeddings();
     // Remove orphaned entries first
@@ -128,13 +129,9 @@ export async function repairIndex(issues) {
             const summary = await summarizeConversation(exchanges);
             fs.writeFileSync(summaryPath, summary, 'utf-8');
             console.log(`  Created summary: ${summary.split(/\s+/).length} words`);
-            // Index exchanges
-            for (const exchange of exchanges) {
-                const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-                const embedding = await generateExchangeEmbedding(exchange.userMessage, exchange.assistantMessage, toolNames);
-                insertExchange(db, exchange, embedding, toolNames);
-            }
-            console.log(`  Indexed ${exchanges.length} exchanges`);
+            // Index exchanges (skips sidechains)
+            const inserted = await indexExchanges(db, exchanges);
+            console.log(`  Indexed ${inserted} exchanges`);
         }
         catch (error) {
             console.error(`Failed to re-index ${conversationPath}:`, error);

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -37,6 +37,35 @@ function sessionIdForSummary(exchanges: ConversationExchange[]): string | undefi
   return exchanges.find(exchange => exchange.sessionId)?.sessionId;
 }
 
+/**
+ * Embed and insert exchanges, skipping sidechains (subagent dispatches, Warmup
+ * stubs, prompt-suggestion sidechains). Search excludes them via
+ * `AND is_sidechain = 0`, so indexing them would embed and store rows no query
+ * can ever return. Returns the number of exchanges actually inserted.
+ *
+ * This is the single place that decides what gets indexed — every indexing
+ * path (full reindex, single session, unprocessed backlog, background sync,
+ * verify/repair) routes through here so the sidechain filter can't be missed.
+ */
+export async function indexExchanges(
+  db: ReturnType<typeof initDatabase>,
+  exchanges: ConversationExchange[]
+): Promise<number> {
+  let inserted = 0;
+  for (const exchange of exchanges) {
+    if (exchange.isSidechain) continue;
+    const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
+    const embedding = await generateExchangeEmbedding(
+      exchange.userMessage,
+      exchange.assistantMessage,
+      toolNames
+    );
+    insertExchange(db, exchange, embedding, toolNames);
+    inserted++;
+  }
+  return inserted;
+}
+
 export async function indexConversations(
   limitToProject?: string,
   maxConversations?: number,
@@ -158,18 +187,7 @@ export async function indexConversations(
 
     // Now process embeddings and DB inserts (fast, sequential is fine)
     for (const conv of toProcess) {
-      for (const exchange of conv.exchanges) {
-        const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-        const embedding = await generateExchangeEmbedding(
-          exchange.userMessage,
-          exchange.assistantMessage,
-          toolNames
-        );
-
-        insertExchange(db, exchange, embedding, toolNames);
-      }
-
-      totalExchanges += conv.exchanges.length;
+      totalExchanges += await indexExchanges(db, conv.exchanges);
       conversationsProcessed++;
 
       // Check if we hit the limit
@@ -230,7 +248,8 @@ export async function indexSession(sessionId: string, concurrency: number = 1, n
       // Parse and summarize
       const exchanges = await parseConversation(sourcePath, project, archivePath);
 
-      if (exchanges.length > 0) {
+      const indexable = exchanges.filter(e => !e.isSidechain);
+      if (indexable.length > 0) {
         // Generate summary (unless --no-summaries)
         const summaryPath = archivePath.replace('.jsonl', '-summary.txt');
         if (!noSummaries && shouldQueueForSummary(summaryPath)) {
@@ -246,18 +265,8 @@ export async function indexSession(sessionId: string, concurrency: number = 1, n
           }
         }
 
-        // Index
-        for (const exchange of exchanges) {
-          const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-          const embedding = await generateExchangeEmbedding(
-            exchange.userMessage,
-            exchange.assistantMessage,
-            toolNames
-          );
-          insertExchange(db, exchange, embedding, toolNames);
-        }
-
-        console.log(`✅ Indexed session ${sessionId}: ${exchanges.length} exchanges`);
+        const inserted = await indexExchanges(db, exchanges);
+        console.log(`✅ Indexed session ${sessionId}: ${inserted} exchanges`);
       }
 
       db.close();
@@ -377,15 +386,7 @@ export async function indexUnprocessed(concurrency: number = 1, noSummaries: boo
   // Now index embeddings
   console.log(`\nIndexing embeddings...`);
   for (const conv of unprocessed) {
-    for (const exchange of conv.exchanges) {
-      const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-      const embedding = await generateExchangeEmbedding(
-        exchange.userMessage,
-        exchange.assistantMessage,
-        toolNames
-      );
-      insertExchange(db, exchange, embedding, toolNames);
-    }
+    await indexExchanges(db, conv.exchanges);
   }
 
   db.close();

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -20,6 +20,69 @@ function shouldSkipConversation(filePath: string): boolean {
   }
 }
 
+/**
+ * Return whether a JSONL conversation file is a sidechain. A file is
+ * "sidechain" when the first record carrying an isSidechain field has it set to
+ * true — subagent dispatches (every record), Warmup stubs, prompt-suggestion
+ * sidechains, ai-title stubs, etc.
+ *
+ * Conservative: if we can't read the file, can't parse a record, or no record
+ * carries the field within the scan cap, return false so the file is copied.
+ * Mixed-content sessions (regular session with some sidechain records inline)
+ * also return false — the indexer-side filter handles per-exchange skipping.
+ */
+export function isSidechainFile(filePath: string): boolean {
+  // Read in chunks and parse only complete (newline-terminated) records, so a
+  // first record larger than one chunk — e.g. a big opening prompt with
+  // attachments — is classified rather than truncated. Bounded so a
+  // pathologically large file is never read in full.
+  const CHUNK = 16384;
+  const MAX_BYTES = 1024 * 1024;
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const chunk = Buffer.alloc(CHUNK);
+    let pending = Buffer.alloc(0);
+    let pos = 0;
+
+    while (pos < MAX_BYTES) {
+      const bytesRead = fs.readSync(fd, chunk, 0, CHUNK, pos);
+      const atEof = bytesRead === 0;
+      if (!atEof) {
+        pos += bytesRead;
+        pending = Buffer.concat([pending, chunk.subarray(0, bytesRead)]);
+      }
+
+      // Parse each complete line; at EOF the trailing bytes are the final line.
+      let nl: number;
+      while ((nl = pending.indexOf(0x0a)) !== -1 || (atEof && pending.length > 0)) {
+        const line = nl !== -1 ? pending.subarray(0, nl) : pending;
+        pending = nl !== -1 ? pending.subarray(nl + 1) : Buffer.alloc(0);
+        if (line.length === 0) continue;
+        let parsed: { isSidechain?: unknown };
+        try {
+          parsed = JSON.parse(line.toString('utf-8'));
+        } catch {
+          // A complete line that won't parse is malformed — stop, copy the file.
+          return false;
+        }
+        if (typeof parsed?.isSidechain === 'boolean') {
+          return parsed.isSidechain;
+        }
+      }
+
+      if (atEof) break;
+    }
+    return false;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch { /* best-effort close */ }
+    }
+  }
+}
+
 export interface SyncResult {
   copied: number;
   skipped: number;
@@ -34,27 +97,22 @@ export interface SyncOptions {
   summaryLimit?: number; // Max summaries to generate per run (default: 10)
 }
 
-function copyIfNewer(src: string, dest: string): boolean {
+function destIsUpToDate(src: string, dest: string): boolean {
+  if (!fs.existsSync(dest)) return false;
+  return fs.statSync(dest).mtimeMs >= fs.statSync(src).mtimeMs;
+}
+
+function copyConversation(src: string, dest: string): void {
   // Ensure destination directory exists
   const destDir = path.dirname(dest);
   if (!fs.existsSync(destDir)) {
     fs.mkdirSync(destDir, { recursive: true });
   }
 
-  // Check if destination exists and is up-to-date
-  if (fs.existsSync(dest)) {
-    const srcStat = fs.statSync(src);
-    const destStat = fs.statSync(dest);
-    if (destStat.mtimeMs >= srcStat.mtimeMs) {
-      return false; // Dest is current, skip
-    }
-  }
-
   // Atomic copy: temp file + rename
   const tempDest = dest + '.tmp.' + process.pid;
   fs.copyFileSync(src, tempDest);
   fs.renameSync(tempDest, dest); // Atomic on same filesystem
-  return true;
 }
 
 export function extractSessionIdFromPath(filePath: string): string | null {
@@ -113,12 +171,18 @@ export async function syncConversations(
       const destFile = path.join(destDir, project, file);
 
       try {
-        const wasCopied = copyIfNewer(srcFile, destFile);
-        if (wasCopied) {
+        // Cheap mtime gate first; only peek inside files we'd actually copy,
+        // so unchanged files aren't re-read on every sync.
+        if (destIsUpToDate(srcFile, destFile)) {
+          result.skipped++;
+        } else if (isSidechainFile(srcFile)) {
+          // Sidechain files are never copied, indexed, or summarized.
+          result.skipped++;
+          continue;
+        } else {
+          copyConversation(srcFile, destFile);
           result.copied++;
           filesToIndex.push(destFile);
-        } else {
-          result.skipped++;
         }
 
         // Check if this file needs a summary (whether newly copied or existing).
@@ -144,9 +208,10 @@ export async function syncConversations(
 
   // Index copied files (unless skipIndex is set)
   if (!options.skipIndex && filesToIndex.length > 0) {
-    const { initDatabase, insertExchange } = await import('./db.js');
-    const { initEmbeddings, generateExchangeEmbedding } = await import('./embeddings.js');
+    const { initDatabase } = await import('./db.js');
+    const { initEmbeddings } = await import('./embeddings.js');
     const { parseConversation } = await import('./parser.js');
+    const { indexExchanges } = await import('./indexer.js');
 
     const db = initDatabase();
     await initEmbeddings();
@@ -161,15 +226,7 @@ export async function syncConversations(
         const project = path.basename(path.dirname(file));
         const exchanges = await parseConversation(file, project, file);
 
-        for (const exchange of exchanges) {
-          const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-          const embedding = await generateExchangeEmbedding(
-            exchange.userMessage,
-            exchange.assistantMessage,
-            toolNames
-          );
-          insertExchange(db, exchange, embedding, toolNames);
-        }
+        await indexExchanges(db, exchanges);
 
         result.indexed++;
       } catch (error) {

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -122,10 +122,11 @@ export async function repairIndex(issues: VerificationResult): Promise<void> {
   console.log('Repairing index...');
 
   // To avoid circular dependencies, we import the indexer functions dynamically
-  const { initDatabase, insertExchange, deleteExchange } = await import('./db.js');
+  const { initDatabase, deleteExchange } = await import('./db.js');
   const { parseConversation } = await import('./parser.js');
-  const { initEmbeddings, generateExchangeEmbedding } = await import('./embeddings.js');
+  const { initEmbeddings } = await import('./embeddings.js');
   const { summarizeConversation } = await import('./summarizer.js');
+  const { indexExchanges } = await import('./indexer.js');
 
   const db = initDatabase();
   await initEmbeddings();
@@ -164,18 +165,10 @@ export async function repairIndex(issues: VerificationResult): Promise<void> {
       fs.writeFileSync(summaryPath, summary, 'utf-8');
       console.log(`  Created summary: ${summary.split(/\s+/).length} words`);
 
-      // Index exchanges
-      for (const exchange of exchanges) {
-        const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-        const embedding = await generateExchangeEmbedding(
-          exchange.userMessage,
-          exchange.assistantMessage,
-          toolNames
-        );
-        insertExchange(db, exchange, embedding, toolNames);
-      }
+      // Index exchanges (skips sidechains)
+      const inserted = await indexExchanges(db, exchanges);
 
-      console.log(`  Indexed ${exchanges.length} exchanges`);
+      console.log(`  Indexed ${inserted} exchanges`);
     } catch (error) {
       console.error(`Failed to re-index ${conversationPath}:`, error);
     }

--- a/test/indexer-sidechain.test.ts
+++ b/test/indexer-sidechain.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import { indexUnprocessed } from '../src/indexer.js';
+import { suppressConsole } from './test-utils.js';
+
+function makeExchangeLines(seq: number, sessionId: string, isSidechain: boolean): string {
+  const userUuid = `user-${seq}-${sessionId}`;
+  const assistantUuid = `asst-${seq}-${sessionId}`;
+  const ts = new Date(2026, 0, 1 + seq).toISOString();
+  const userLine = JSON.stringify({
+    parentUuid: seq === 1 ? null : `asst-${seq - 1}-${sessionId}`,
+    isSidechain,
+    userType: 'external',
+    cwd: '/test/project',
+    sessionId,
+    version: '2.0.9',
+    gitBranch: 'main',
+    type: 'user',
+    message: { role: 'user', content: `User question number ${seq} about topic-${seq}` },
+    uuid: userUuid,
+    timestamp: ts,
+  });
+  const assistantLine = JSON.stringify({
+    parentUuid: userUuid,
+    isSidechain,
+    userType: 'external',
+    cwd: '/test/project',
+    sessionId,
+    version: '2.0.9',
+    gitBranch: 'main',
+    type: 'assistant',
+    message: {
+      model: 'claude-sonnet-4-5',
+      role: 'assistant',
+      content: [{ type: 'text', text: `Assistant answer ${seq} discussing details of topic-${seq}` }],
+    },
+    uuid: assistantUuid,
+    timestamp: ts,
+  });
+  return userLine + '\n' + assistantLine + '\n';
+}
+
+describe('indexer: skip sidechain exchanges', () => {
+  let testDir: string;
+  let projectsDir: string;
+  let configDir: string;
+  let dbPath: string;
+  let restoreConsole: () => void;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'em-sidechain-test-'));
+    projectsDir = join(testDir, 'projects');
+    configDir = join(testDir, 'config');
+    dbPath = join(testDir, 'test.db');
+    mkdirSync(projectsDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+
+    process.env.TEST_PROJECTS_DIR = projectsDir;
+    process.env.EPISODIC_MEMORY_CONFIG_DIR = configDir;
+    process.env.TEST_DB_PATH = dbPath;
+    restoreConsole = suppressConsole();
+  });
+
+  afterEach(() => {
+    restoreConsole();
+    delete process.env.TEST_PROJECTS_DIR;
+    delete process.env.EPISODIC_MEMORY_CONFIG_DIR;
+    delete process.env.TEST_DB_PATH;
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  function countExchanges(): { total: number; sidechain: number } {
+    const db = new Database(dbPath);
+    const total = (db.prepare('SELECT COUNT(*) AS c FROM exchanges').get() as { c: number }).c;
+    const sidechain = (db.prepare('SELECT COUNT(*) AS c FROM exchanges WHERE is_sidechain = 1').get() as { c: number }).c;
+    db.close();
+    return { total, sidechain };
+  }
+
+  it('does not insert sidechain exchanges into the DB', async () => {
+    const projectDir = join(projectsDir, 'project-a');
+    mkdirSync(projectDir, { recursive: true });
+
+    // Mixed transcript: one non-sidechain exchange and one sidechain exchange.
+    writeFileSync(
+      join(projectDir, 'session-1.jsonl'),
+      makeExchangeLines(1, 'session-1', false) + makeExchangeLines(2, 'session-1', true),
+      'utf-8'
+    );
+
+    await indexUnprocessed(1, true);
+
+    const { total, sidechain } = countExchanges();
+    expect(total).toBe(1);
+    expect(sidechain).toBe(0);
+  });
+
+  it('inserts nothing when every exchange is sidechain', async () => {
+    const projectDir = join(projectsDir, 'project-a');
+    mkdirSync(projectDir, { recursive: true });
+
+    writeFileSync(
+      join(projectDir, 'session-1.jsonl'),
+      makeExchangeLines(1, 'session-1', true) + makeExchangeLines(2, 'session-1', true),
+      'utf-8'
+    );
+
+    await indexUnprocessed(1, true);
+
+    expect(countExchanges().total).toBe(0);
+  });
+});

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -21,12 +21,18 @@ describe('sync command', () => {
     // Create source directory
     mkdirSync(sourceDir, { recursive: true });
 
+    // Isolate from the user's real exclude.txt / config so subagents/ dirs
+    // aren't pre-filtered at discovery.
+    process.env.EPISODIC_MEMORY_CONFIG_DIR = join(testDir, 'config');
+    mkdirSync(process.env.EPISODIC_MEMORY_CONFIG_DIR, { recursive: true });
+
     // Set DB path for sync to use
     process.env.TEST_DB_PATH = dbPath;
   });
 
   afterEach(() => {
     delete process.env.TEST_DB_PATH;
+    delete process.env.EPISODIC_MEMORY_CONFIG_DIR;
     try {
       rmSync(testDir, { recursive: true, force: true });
     } catch (error) {
@@ -246,5 +252,164 @@ describe('sync command', () => {
     const sentinelsAfter2 = readdirSync(join(destDir, 'project-a'))
       .filter(f => f.endsWith('-summary.txt'));
     expect(sentinelsAfter2.length).toBe(zeroExchangeFileCount);
+  });
+
+  it('should not copy sidechain files (top-level Warmup stub)', async () => {
+    mkdirSync(join(sourceDir, 'project-a'), { recursive: true });
+    const sidechainFile = join(sourceDir, 'project-a', 'agent-a01.jsonl');
+    writeFileSync(
+      sidechainFile,
+      JSON.stringify({
+        isSidechain: true,
+        type: 'user',
+        message: { role: 'user', content: 'Warmup' },
+        uuid: 'warmup-1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }) + '\n',
+      'utf-8'
+    );
+
+    const result = await syncConversations(sourceDir, destDir, { skipIndex: true, skipSummaries: true });
+
+    expect(result.copied).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(existsSync(join(destDir, 'project-a', 'agent-a01.jsonl'))).toBe(false);
+  });
+
+  it('should not copy sidechain files (nested subagent dispatch)', async () => {
+    mkdirSync(join(sourceDir, 'project-a', 'parent-session', 'subagents'), { recursive: true });
+    const sidechainFile = join(sourceDir, 'project-a', 'parent-session', 'subagents', 'agent-a01.jsonl');
+    writeFileSync(
+      sidechainFile,
+      JSON.stringify({
+        isSidechain: true,
+        type: 'user',
+        cwd: '/test/project',
+        message: { role: 'user', content: 'Investigate the bug' },
+        uuid: 'sub-1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }) + '\n' +
+      JSON.stringify({
+        isSidechain: true,
+        type: 'assistant',
+        cwd: '/test/project',
+        message: { role: 'assistant', content: 'Found it in foo.ts' },
+        uuid: 'sub-2',
+        timestamp: '2026-01-01T00:00:01.000Z',
+      }) + '\n',
+      'utf-8'
+    );
+
+    const result = await syncConversations(sourceDir, destDir, { skipIndex: true, skipSummaries: true });
+
+    expect(result.copied).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(existsSync(join(destDir, 'project-a', 'parent-session', 'subagents', 'agent-a01.jsonl'))).toBe(false);
+  });
+
+  it('should copy regular non-sidechain conversation files', async () => {
+    mkdirSync(join(sourceDir, 'project-a'), { recursive: true });
+    const regularFile = join(sourceDir, 'project-a', 'session-1.jsonl');
+    writeFileSync(
+      regularFile,
+      JSON.stringify({
+        isSidechain: false,
+        type: 'user',
+        cwd: '/test/project',
+        message: { role: 'user', content: 'Hello' },
+        uuid: 'reg-1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }) + '\n',
+      'utf-8'
+    );
+
+    const result = await syncConversations(sourceDir, destDir, { skipIndex: true, skipSummaries: true });
+
+    expect(result.copied).toBe(1);
+    expect(existsSync(join(destDir, 'project-a', 'session-1.jsonl'))).toBe(true);
+  });
+
+  it('does not index inline sidechain exchanges from a mixed file', async () => {
+    mkdirSync(join(sourceDir, 'project-a'), { recursive: true });
+
+    // A regular session (first record non-sidechain, so the file is copied)
+    // that also carries inline sidechain exchanges — the case the per-exchange
+    // filter must catch on the sync indexing path, not just the manual reindex.
+    const rec = (uuid: string, parent: string | null, role: string, text: string, isSidechain: boolean) =>
+      JSON.stringify({
+        parentUuid: parent,
+        isSidechain,
+        userType: 'external',
+        cwd: '/test/project',
+        sessionId: 'mix-1',
+        version: '2.0.9',
+        gitBranch: 'main',
+        type: role,
+        message:
+          role === 'user'
+            ? { role: 'user', content: text }
+            : { model: 'claude-sonnet-4-5', role: 'assistant', content: [{ type: 'text', text }] },
+        uuid,
+        timestamp: '2026-01-01T00:00:00.000Z',
+      });
+
+    const mixed = [
+      rec('m-u1', null, 'user', 'Real question about the indexer', false),
+      rec('m-a1', 'm-u1', 'assistant', 'Real answer about the indexer', false),
+      rec('m-u2', 'm-a1', 'user', 'Subagent internal step', true),
+      rec('m-a2', 'm-u2', 'assistant', 'Subagent internal finding', true),
+    ].join('\n') + '\n';
+    writeFileSync(join(sourceDir, 'project-a', 'mix-1.jsonl'), mixed, 'utf-8');
+
+    const result = await syncConversations(sourceDir, destDir, { skipSummaries: true });
+
+    // File is copied (its first record is non-sidechain) and indexed...
+    expect(result.copied).toBe(1);
+    expect(result.indexed).toBe(1);
+
+    // ...but only the non-sidechain exchange lands in the DB.
+    const db = new Database(dbPath, { readonly: true });
+    const total = (db.prepare('SELECT COUNT(*) AS c FROM exchanges').get() as { c: number }).c;
+    const sidechain = (db.prepare('SELECT COUNT(*) AS c FROM exchanges WHERE is_sidechain = 1').get() as { c: number }).c;
+    db.close();
+
+    expect(total).toBe(1);
+    expect(sidechain).toBe(0);
+  });
+
+  it('skips a sidechain file whose first record is larger than the read chunk', async () => {
+    mkdirSync(join(sourceDir, 'project-a'), { recursive: true });
+
+    // A subagent dispatch whose opening record (big prompt + attachments) is
+    // larger than the chunk size — the file-level peek must read the whole
+    // record to see isSidechain rather than truncating and copying it.
+    const bigPrompt = 'x'.repeat(40000);
+    const sidechainFile = join(sourceDir, 'project-a', 'agent-big01.jsonl');
+    writeFileSync(
+      sidechainFile,
+      JSON.stringify({
+        isSidechain: true,
+        type: 'user',
+        cwd: '/test/project',
+        message: { role: 'user', content: bigPrompt },
+        uuid: 'big-1',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }) + '\n' +
+      JSON.stringify({
+        isSidechain: true,
+        type: 'assistant',
+        cwd: '/test/project',
+        message: { role: 'assistant', content: 'done' },
+        uuid: 'big-2',
+        timestamp: '2026-01-01T00:00:01.000Z',
+      }) + '\n',
+      'utf-8'
+    );
+
+    const result = await syncConversations(sourceDir, destDir, { skipIndex: true, skipSummaries: true });
+
+    expect(result.copied).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(existsSync(join(destDir, 'project-a', 'agent-big01.jsonl'))).toBe(false);
   });
 });


### PR DESCRIPTION
# perf: skip copying and indexing sidechain conversations to reduce disk usage

## Description

The primary goal of this PR is to **reduce episodic-memory's on-disk footprint**. The plugin copies and indexes sidechain conversations (subagent dispatches, Warmup/`ai-title` stubs, prompt-suggestion sidechains) that search already excludes and never returns. In my install that was **~40% of the SQLite DB and ~25% of the conversation archive** — disk spent on data no query can reach. This PR stops copying and indexing them so that storage isn't consumed going forward. It also avoids the embedding work for those exchanges, but the motivation is storage, not speed — sync latency is roughly unchanged. If a sidechain type later proves worth searching, it can be added with summarisation and query support.

- `sync.ts` copies every discovered `.jsonl` from `~/.claude/projects/` into `~/.config/superpowers/conversation-archive/`, including nested subagent dispatches at `<project>/<session>/subagents/agent-*.jsonl` and top-level harness stubs at `<project>/agent-*.jsonl` (Warmup, prompt-suggestion sidechains, `ai-title`).
- `indexer.ts` then embeds every parsed exchange into a 384-float vector and inserts rows into `exchanges` and `vec_exchanges`, regardless of `isSidechain`.
- `search.ts` unconditionally excludes them via `AND e.is_sidechain = 0` in both vector and text query paths.

This is a storage change, not a behavior change: search results are identical before and after, because the `AND e.is_sidechain = 0` filter (originally requested in #42) already hides these exchanges from every query and has no off switch. That left an asymmetry — the data is filtered out of every result, yet still embedded, written to the DB, and copied to disk. This PR removes that wasted storage by stopping at copy time and index time, matching the filter that search already applies.

## Why These Files Exist

All `isSidechain: true`, all legitimate Claude Code artifacts:

- **Explicit subagent dispatches** — Agent/Task tool transcripts under `<project>/<parent-session>/subagents/`. The agent's report-back already lives in the parent transcript and is searchable; the sidechain holds only the agent's internal trace (files read, intermediate reasoning).
- **Warmup and harness records** — top-level `<project>/agent-aXXX.jsonl`. Prompt-cache warmup stubs (`{"content":"Warmup"}`), prompt-suggestion sidechains, `ai-title` stubs. Most parse to 0 exchanges.
- **`/btw` asides** — Claude Code's `/btw` ("by the way") command asks a quick question off the main thread; its records are `isSidechain: true` and never join the main conversation. We considered surfacing these but intentionally don't: like every sidechain here they're already excluded from search by the `is_sidechain = 0` filter, so this PR doesn't change their searchability, and they're a small volume of deliberately ephemeral content — `/btw` exists precisely to keep asides out of history — so summarising and indexing them for search isn't worth the cost.

None have semantic value for cross-session search *as currently surfaced*.

## Change

Two layers:

**1. Skip sidechain exchanges at index time.** A single exported `indexExchanges()` in `src/indexer.ts` owns the embed + insert loop and short-circuits on `isSidechain`, skipping both the embedding generation and the DB insert — symmetric with the existing `AND e.is_sidechain = 0` filter in `src/search.ts`. All five indexing paths route through it (full reindex, single session, unprocessed backlog, **background sync**, and **verify/repair**), so the filter can't be applied to some paths and missed on others. The two that matter most are `syncConversations` — the background path that runs on every session start — and `repairIndex`; both would otherwise index inline sidechain exchanges from mixed-content files. The helper returns the inserted (non-sidechain) count, which the user-facing "Exchanges: N" logs report.

**2. Skip sidechain files at copy time.** New `isSidechainFile()` in `src/sync.ts` reads the file in chunks and inspects whole (newline-terminated) records until one carries an `isSidechain` flag, returning that value. It reads **complete records** rather than a fixed byte window, so a subagent file whose opening record is large (a big initial prompt with attachments) is classified correctly instead of truncated; the scan is bounded (1 MB) so a pathologically large file is never read in full. Conservative on every error path (unreadable file, an unparseable record, or no record carrying the field within the cap) so ambiguous and mixed-content files still get copied and handled by the per-exchange filter above. The check is gated behind a cheap mtime comparison, so unchanged files aren't re-read on every sync. Sidechain files are counted as `skipped`, never copied, and don't enter `filesToIndex` or `filesToSummarize`.

Schema groundwork for the `is_sidechain` column stays in place, so a future opt-in feature could lift the search filter and re-index from archive.

## Tests

`test/indexer-sidechain.test.ts` (new, 2 tests) — the manual reindex path (`indexUnprocessed`):

- Mixed transcript (one sidechain + one non-sidechain exchange) → `COUNT(*) FROM exchanges` is 1, `COUNT(*) WHERE is_sidechain = 1` is 0.
- All-sidechain transcript → `COUNT(*) FROM exchanges` is 0.

`test/sync.test.ts` (5 new tests):

- Top-level `agent-a01.jsonl` Warmup stub → not copied.
- Nested `<session>/subagents/agent-a01.jsonl` subagent dispatch → not copied.
- Regular non-sidechain conversation → copied as before.
- Mixed-content file (non-sidechain first record + inline sidechain exchanges) synced **with indexing enabled** → file is copied, but only the non-sidechain exchange lands in the DB. This pins the background `syncConversations` path, which the indexer test above doesn't exercise; it indexed both rows before this fix.
- Sidechain file whose first record is larger than the read chunk → still skipped at copy time (guards the complete-record read described above).

The sync test fixture now sets `EPISODIC_MEMORY_CONFIG_DIR` to isolate from any pre-existing `exclude.txt` that would have pre-filtered `subagents/` dirs at discovery and masked the test signal. Existing `test/incremental-indexing.test.ts` and `test/exclude-nested.test.ts` still pass.

## Validation

Beyond the unit suite, the change was exercised against real transcripts in an isolated scratch environment (real files read-only; scratch DB and archive, summaries off):

- A 41-file sample (32 subagent sidechains + 9 main conversations) synced to **9 copied, 32 skipped, 0 sidechain rows indexed**; the main conversations were indexed and returned from search as expected, and no real conversation was mis-skipped.
- This is where the large-first-record case surfaced. One subagent file had an 8 401-byte opening record. The earlier fixed-window peek truncated it mid-record, mis-classified it as non-sidechain, and copied it — search stayed correct (the per-exchange filter indexed 0 of its rows), but the file-level archive saving was lost. Reading complete records fixes it: the file is now skipped at copy time. That motivated layer 2's complete-record read and is locked in by a regression test.

## Environment

- episodic-memory v1.4.2

## For existing installs

This PR only prevents *new* sidechain data. Existing archived files and DB rows from prior versions stay until cleaned up. To reclaim space, run from the plugin directory:

```sh
# 1. Delete sidechain rows from the DB (handles vec_exchanges and tool_calls).
node -e "
  const { initDatabase, deleteExchange } = require('./dist/db.js');
  const db = initDatabase();
  const ids = db.prepare('SELECT id FROM exchanges WHERE is_sidechain = 1').all();
  const tx = db.transaction(rows => { for (const {id} of rows) deleteExchange(db, id); });
  tx(ids);
  db.exec('VACUUM');
  console.log('Deleted ' + ids.length + ' sidechain rows');
"

# 2. Remove archived nested-dispatch directories.
find ~/.config/superpowers/conversation-archive -type d -name subagents -exec rm -rf {} +
```

Step 2 covers `<session>/subagents/` dirs; top-level `<project>/agent-aXXX.jsonl` Warmup stubs from prior versions are smaller and can be left in place or removed manually. After this PR lands, no new sidechain files are written, so the cleanup is one-shot.

Safe to skip — search results are unaffected either way (sidechain rows weren't returned before, aren't now). Worth running if disk pressure matters; ~40% DB and ~25% archive reduction in my install.
