### PR TITLE
fix(search): over-fetch vector candidates so the sidechain filter can't starve results

### DIFF
--- a/dist/mcp-server.js
+++ b/dist/mcp-server.js
@@ -25111,7 +25111,7 @@ async function searchConversations(query, options = {}) {
   if (mode === "vector" || mode === "both") {
     await initEmbeddings();
     const queryEmbedding = await generateQueryEmbedding(query);
-    const k2 = hasMetadataFilters(options) ? limit * 3 : limit;
+    const k2 = Math.max(hasMetadataFilters(options) ? limit * 3 : limit, limit + 100);
     const stmt = db.prepare(`
       SELECT
         ${EXCHANGE_SELECT_COLUMNS},

--- a/dist/search.js
+++ b/dist/search.js
@@ -123,11 +123,17 @@ export async function searchConversations(query, options = {}) {
     const { sql: filterClause, params: filterParams } = buildSearchFilters(options);
     if (mode === 'vector' || mode === 'both') {
         // Vector similarity search.
-        // vec0 applies KNN before WHERE, so when extra metadata filters are
-        // active we ask for more candidates than `limit` and trim afterwards.
+        // vec0 applies the KNN `k` cutoff BEFORE the WHERE clause, so every
+        // post-filter can shrink the result set below `limit`. The `is_sidechain = 0`
+        // filter is always applied, and subagent (sidechain) exchanges frequently
+        // crowd the nearest neighbours, so requesting exactly `limit` candidates
+        // returns far fewer than `limit` real hits (often zero at small limits).
+        // Over-fetch candidates (with extra headroom for the always-on sidechain
+        // filter plus any metadata filters) and trim to `limit` after filtering.
+        // See #42, which introduced the sidechain filter.
         await initEmbeddings();
         const queryEmbedding = await generateQueryEmbedding(query);
-        const k = hasMetadataFilters(options) ? limit * 3 : limit;
+        const k = Math.max(hasMetadataFilters(options) ? limit * 3 : limit, limit + 100);
         const stmt = db.prepare(`
       SELECT
         ${EXCHANGE_SELECT_COLUMNS},

--- a/src/search.ts
+++ b/src/search.ts
@@ -148,11 +148,17 @@ export async function searchConversations(
 
   if (mode === 'vector' || mode === 'both') {
     // Vector similarity search.
-    // vec0 applies KNN before WHERE, so when extra metadata filters are
-    // active we ask for more candidates than `limit` and trim afterwards.
+    // vec0 applies the KNN `k` cutoff BEFORE the WHERE clause, so every
+    // post-filter can shrink the result set below `limit`. The `is_sidechain = 0`
+    // filter is always applied, and subagent (sidechain) exchanges frequently
+    // crowd the nearest neighbours, so requesting exactly `limit` candidates
+    // returns far fewer than `limit` real hits (often zero at small limits).
+    // Over-fetch candidates (with extra headroom for the always-on sidechain
+    // filter plus any metadata filters) and trim to `limit` after filtering.
+    // See #42, which introduced the sidechain filter.
     await initEmbeddings();
     const queryEmbedding = await generateQueryEmbedding(query);
-    const k = hasMetadataFilters(options) ? limit * 3 : limit;
+    const k = Math.max(hasMetadataFilters(options) ? limit * 3 : limit, limit + 100);
 
     const stmt = db.prepare(`
       SELECT

--- a/test/search-sidechain-recall.test.ts
+++ b/test/search-sidechain-recall.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { indexUnprocessed } from '../src/indexer.js';
+import { searchConversations } from '../src/search.js';
+import { suppressConsole } from './test-utils.js';
+
+/**
+ * Build one user/assistant exchange. `isSidechain` controls whether it is a
+ * subagent dispatch (excluded from search results by `is_sidechain = 0`). The
+ * exchange text embeds `topic` so semantic queries can rank it.
+ */
+function makeExchangeLines(opts: {
+  seq: number;
+  sessionId: string;
+  topic: string;
+  isSidechain: boolean;
+}): string {
+  const { seq, sessionId, topic, isSidechain } = opts;
+  const userUuid = `u-${seq}-${sessionId}`;
+  const assistantUuid = `a-${seq}-${sessionId}`;
+  const ts = new Date(2026, 0, 1 + seq).toISOString();
+  const userLine = JSON.stringify({
+    parentUuid: null,
+    isSidechain,
+    userType: 'external',
+    cwd: '/test/project',
+    sessionId,
+    version: '2.0.9',
+    gitBranch: 'main',
+    type: 'user',
+    message: { role: 'user', content: `Question about ${topic}` },
+    uuid: userUuid,
+    timestamp: ts,
+  });
+  const assistantLine = JSON.stringify({
+    parentUuid: userUuid,
+    isSidechain,
+    userType: 'external',
+    cwd: '/test/project',
+    sessionId,
+    version: '2.0.9',
+    gitBranch: 'main',
+    type: 'assistant',
+    message: {
+      model: 'claude-sonnet-4-5',
+      role: 'assistant',
+      content: [{ type: 'text', text: `Answer about ${topic}` }],
+    },
+    uuid: assistantUuid,
+    timestamp: ts,
+  });
+  return userLine + '\n' + assistantLine + '\n';
+}
+
+describe('vector search recall vs sidechain crowding', () => {
+  let testDir: string;
+  let projectsDir: string;
+  let archiveDir: string;
+  let configDir: string;
+  let dbPath: string;
+  let restoreConsole: () => void;
+
+  beforeEach(async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'em-sidechain-test-'));
+    projectsDir = join(testDir, 'projects');
+    archiveDir = join(testDir, 'archive');
+    configDir = join(testDir, 'config');
+    dbPath = join(testDir, 'test.db');
+    mkdirSync(projectsDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+
+    process.env.TEST_PROJECTS_DIR = projectsDir;
+    process.env.TEST_ARCHIVE_DIR = archiveDir;
+    process.env.EPISODIC_MEMORY_CONFIG_DIR = configDir;
+    process.env.TEST_DB_PATH = dbPath;
+    restoreConsole = suppressConsole();
+
+    const project = join(projectsDir, 'project-a');
+    mkdirSync(project, { recursive: true });
+
+    // The single real (non-sidechain) exchange the user wants to find. It is on
+    // the same concept as the query but phrased differently, so it ranks just
+    // below the sidechains that match the query wording exactly.
+    writeFileSync(
+      join(project, 'real-session.jsonl'),
+      makeExchangeLines({
+        seq: 1,
+        sessionId: 'real-session',
+        topic: 'rolling out containerized services to a managed orchestration cluster',
+        isSidechain: false,
+      }),
+      'utf-8'
+    );
+
+    // Many subagent (sidechain) exchanges whose text matches the query wording
+    // exactly, so they are the nearest neighbours. Because vec0 applies the `k`
+    // cutoff before `is_sidechain = 0`, with `k = limit` the top-`limit` slots
+    // are all these sidechains and the real exchange gets filtered out, yielding
+    // zero results.
+    for (let i = 0; i < 20; i++) {
+      writeFileSync(
+        join(project, `agent-${i}.jsonl`),
+        makeExchangeLines({ seq: 10 + i, sessionId: `agent-${i}`, topic: 'kubernetes deployment', isSidechain: true }),
+        'utf-8'
+      );
+    }
+
+    await indexUnprocessed(1, true);
+  });
+
+  afterEach(() => {
+    restoreConsole();
+    delete process.env.TEST_PROJECTS_DIR;
+    delete process.env.TEST_ARCHIVE_DIR;
+    delete process.env.EPISODIC_MEMORY_CONFIG_DIR;
+    delete process.env.TEST_DB_PATH;
+    try { rmSync(testDir, { recursive: true, force: true }); } catch {}
+  });
+
+  it('returns the real exchange at a small limit despite many sidechain neighbours', async () => {
+    const results = await searchConversations('kubernetes deployment', { mode: 'vector', limit: 3 });
+    expect(results.length).toBe(1);
+    for (const r of results) {
+      expect(r.exchange.isSidechain).toBe(false);
+    }
+  });
+
+  it('never returns sidechain exchanges from vector search', async () => {
+    const results = await searchConversations('kubernetes deployment', { mode: 'vector', limit: 10 });
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      expect(r.exchange.isSidechain).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Vector/semantic search returns far fewer results than `limit`, often zero at small limits, while text search works fine. On a ~31k-exchange index (~13% sidechain), `mode: "vector"` returned: limit 3 -> 0, limit 10 -> 2, limit 25 -> 11.

## Cause

In `searchConversations`, the vec0 KNN query is:

```sql
WHERE vec.embedding MATCH ? AND k = ?
  AND e.is_sidechain = 0
```

vec0 applies the `k` cutoff before the `WHERE`, but `k` is only inflated (`limit * 3`) when metadata filters are present, never for the always-on `is_sidechain = 0` filter. Subagent (sidechain) exchanges crowd the nearest neighbours and get removed after the cut, leaving fewer than `limit` results (often none at small limits). Text search is unaffected because it does not use `k`.

The `is_sidechain = 0` filter was added in #42; this is the latent recall regression introduced alongside it.

Related: #111 (skip indexing sidechains) would hide this for fresh installs, but its stated assumption that search results are identical before and after does not hold for the vector path, and it does not fix the query for any index that still contains sidechain rows.

## Fix

Over-fetch candidates with headroom for the always-on sidechain filter (`limit + 100`, or `limit * 3` when metadata filters are also active) and trim to `limit` after filtering (the existing trim handles the upper bound). This matches the existing `limit * 3` idiom; a fully guaranteed `limit` would require iterative `k` expansion, which could be a follow-up.

## Test

Adds `test/search-sidechain-recall.test.ts`: indexes one real exchange among 20 sidechain neighbours on the query topic, then asserts vector search still returns it at `limit: 3` and never returns sidechain rows. The test fails on the previous `k = limit` behaviour and passes with the fix.

## Verification

- Full suite: 208 passed, 1 pre-existing failure (`show.test.ts` date-format assertion) that also fails on clean `main`, unrelated to this change.
- `npm run build` clean.
