### PR TITLE
Make embedding model and task prefixes configurable via env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- The embedding model and its task prefixes are now configurable via
+  `EPISODIC_MEMORY_EMBEDDING_MODEL`, `EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX`,
+  and `EPISODIC_MEMORY_EMBEDDING_PASSAGE_PREFIX`. The default behavior is
+  unchanged (`Xenova/bge-small-en-v1.5`, BGE query prefix, no passage prefix).
+  This unblocks non-English corpora: on a Korean-language corpus the default
+  English-only model placed the right conversation in the top-3 for 1/3 test
+  queries, while `Xenova/multilingual-e5-small` (same 384 dimensions) scored
+  3/3 on identical data. Models must stay 384-dim, and switching requires a
+  reindex (docs added to README).
+
 ## [1.4.2] - 2026-05-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -189,6 +189,31 @@ export EPISODIC_MEMORY_CODEX_BIN=/path/to/codex
 
 These settings only affect episodic-memory's summarization calls, not your interactive Claude Code or Codex sessions.
 
+## Embedding Model Configuration
+
+The default embedding model (`Xenova/bge-small-en-v1.5`) is English-only. If your
+conversations are mostly in another language, semantic search quality degrades
+sharply — in an A/B on a Korean-language corpus (same conversations, same queries),
+the default model placed the right conversation in the top-3 for 1/3 queries, while
+`Xenova/multilingual-e5-small` (also 384-dim) scored 3/3.
+
+```bash
+# Any Transformers.js-compatible model id. MUST be 384-dim (schema is fixed).
+export EPISODIC_MEMORY_EMBEDDING_MODEL=Xenova/multilingual-e5-small
+
+# Task prefixes are model-specific. e5-family models expect these:
+export EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX="query: "
+export EPISODIC_MEMORY_EMBEDDING_PASSAGE_PREFIX="passage: "
+```
+
+Caveats:
+
+- The model must produce **384-dimensional** embeddings (the `vec_exchanges` schema is fixed).
+- Switching models does not bump `EMBEDDING_VERSION`, so existing rows are not
+  auto-migrated. Reindex after switching, and never mix two models in one index.
+- Set the same values for every process that touches the index (sync hook, MCP
+  server, CLI) — e.g. in your shell profile or the hook environment.
+
 Codex summarization requires `codex-cli 0.130.0` or newer. If Codex app-server summarization is unavailable, sync logs the reason and falls back to transcript-text summarization.
 
 ### What's Affected

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -16,10 +16,24 @@ env.useBrowserCache = false;
  * BGE models recommend prepending a task prefix to QUERY embeddings only
  * (passages/documents go through unmodified). See `withQueryPrefix` and
  * `generateQueryEmbedding` below.
+ *
+ * Env overrides (for non-English corpora — the default model is English-only):
+ * - EPISODIC_MEMORY_EMBEDDING_MODEL: any Transformers.js-compatible model id.
+ *   MUST produce 384-dim embeddings (the vec_exchanges schema is fixed at 384).
+ * - EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX: query-side task prefix. Defaults to
+ *   the BGE sentence prefix; e5-family models want "query: " instead.
+ * - EPISODIC_MEMORY_EMBEDDING_PASSAGE_PREFIX: passage-side prefix, prepended
+ *   before the 2000-char truncation. Defaults to "" (BGE passages go through
+ *   unmodified); e5-family models want "passage: ".
+ * Switching models does not bump EMBEDDING_VERSION — reindex after switching,
+ * and never mix models in one index.
  */
-const MODEL_ID = 'Xenova/bge-small-en-v1.5';
+const MODEL_ID = process.env.EPISODIC_MEMORY_EMBEDDING_MODEL || 'Xenova/bge-small-en-v1.5';
 const MODEL_DTYPE = 'q8';
-export const BGE_QUERY_PREFIX = 'Represent this sentence for searching relevant passages: ';
+export const BGE_QUERY_PREFIX =
+  process.env.EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX ??
+  'Represent this sentence for searching relevant passages: ';
+const PASSAGE_PREFIX = process.env.EPISODIC_MEMORY_EMBEDDING_PASSAGE_PREFIX ?? '';
 
 let embeddingPipeline: FeatureExtractionPipeline | null = null;
 
@@ -84,5 +98,5 @@ export async function generateExchangeEmbedding(
     combined += `\n\nTools: ${toolNames.join(', ')}`;
   }
 
-  return generateEmbedding(combined);
+  return generateEmbedding(PASSAGE_PREFIX + combined);
 }

--- a/test/embedding-env.test.ts
+++ b/test/embedding-env.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// The embedding model id and task prefixes are read from env at module load,
+// so each test re-imports a fresh copy of the module via vi.resetModules().
+const ENV_KEYS = [
+  'EPISODIC_MEMORY_EMBEDDING_MODEL',
+  'EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX',
+  'EPISODIC_MEMORY_EMBEDDING_PASSAGE_PREFIX',
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  vi.resetModules();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  vi.resetModules();
+});
+
+describe('embedding env overrides', () => {
+  it('defaults to the BGE query prefix when env is unset', async () => {
+    for (const k of ENV_KEYS) delete process.env[k];
+    const { BGE_QUERY_PREFIX } = await import('../src/embeddings.js');
+    expect(BGE_QUERY_PREFIX).toBe('Represent this sentence for searching relevant passages: ');
+  });
+
+  it('EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX overrides the query prefix', async () => {
+    process.env.EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX = 'query: ';
+    const { BGE_QUERY_PREFIX, withQueryPrefix } = await import('../src/embeddings.js');
+    expect(BGE_QUERY_PREFIX).toBe('query: ');
+    expect(withQueryPrefix('워크트리 브랜치 규칙')).toBe('query: 워크트리 브랜치 규칙');
+  });
+
+  it('empty-string query prefix is honored (?? semantics, not ||)', async () => {
+    process.env.EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX = '';
+    const { BGE_QUERY_PREFIX, withQueryPrefix } = await import('../src/embeddings.js');
+    expect(BGE_QUERY_PREFIX).toBe('');
+    expect(withQueryPrefix('plain query')).toBe('plain query');
+  });
+
+  it('withQueryPrefix stays idempotent under an overridden prefix', async () => {
+    process.env.EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX = 'query: ';
+    const { withQueryPrefix } = await import('../src/embeddings.js');
+    expect(withQueryPrefix(withQueryPrefix('doubled?'))).toBe('query: doubled?');
+  });
+});


### PR DESCRIPTION
## Why
The default embedding model (`Xenova/bge-small-en-v1.5`) is English-only. On non-English corpora, retrieval quality collapses. A/B on a Korean-language corpus (3,862 real Claude Code conversations, same pre-registered queries, hit@3 against known-answer sessions):

| model | primary-gate hit@3 |
|---|---|
| bge-small-en-v1.5 (default) | 1/3 (similarity band compressed to 54–68%) |
| multilingual-e5-small (384-dim, q8) | **3/3** |

## What
Three env overrides, all defaulting to current behavior — no behavior change unless set:
- `EPISODIC_MEMORY_EMBEDDING_MODEL` (default `Xenova/bge-small-en-v1.5`; must stay 384-dim)
- `EPISODIC_MEMORY_EMBEDDING_QUERY_PREFIX` (default: BGE sentence prefix; e5-family wants `query: `)
- `EPISODIC_MEMORY_EMBEDDING_PASSAGE_PREFIX` (default `""`; e5-family wants `passage: `, applied before the 2000-char truncation)

Docs cover the 384-dim constraint and the reindex-after-switching caveat (`EMBEDDING_VERSION` is not bumped by env changes). Tests: `test/embedding-env.test.ts` — override, `??` empty-string semantics, idempotency under an overridden prefix. Subset run (embedding-env + query-prefix): 7/7.

Happily running this in production against a mixed Korean/English corpus. Thanks for the tool — the conversation-archive design saved us from Claude Code's ~30-day transcript cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)