### PR TITLE
fix(summarizer): isolate subprocess from user ~/.claude settings (settingSources: [])

### DIFF
--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -104,6 +104,17 @@ function extractSummary(text: string): string {
  * ~/.claude/projects/ (#83). Without it, every summarization spawns a fake
  * session JSONL that pollutes the IDE session sidebar. The option is honored
  * by claude-agent-sdk >= 0.2.0.
+ *
+ * settingSources: [] runs the summarizer subprocess in SDK isolation mode so it
+ * does NOT load the user's ~/.claude filesystem settings. Without it, the spawned
+ * subprocess fires every SessionStart/UserPromptSubmit hook the user has configured,
+ * and those hooks can inject large context (rules files, CLAUDE.md, memory) that
+ * overflows the summarizer model's context window BEFORE the conversation is added.
+ * The API then returns HTTP 400 "Prompt is too long" as a result message with
+ * is_error:true / subtype:'success', which callClaude() throws as the opaque
+ * SummarizerSdkError('success') — so EVERY summary fails for users with heavy
+ * ~/.claude hook configs. Isolation drops the prompt to the conversation text alone.
+ * (Settings default to loaded — CLI parity — when settingSources is omitted.)
  */
 export function buildSummarizerQueryOptions(args: {
   model: string;
@@ -117,6 +128,7 @@ export function buildSummarizerQueryOptions(args: {
     env: getApiEnv(),
     resume: sessionId,
     persistSession: false,
+    settingSources: [],
     // Resume looks up the session under ~/.claude/projects/<encoded-cwd>/, so pass the recorded cwd when it still exists on disk.
     ...(cwd && fs.existsSync(cwd) ? { cwd } : {}),
     // Don't override systemPrompt when resuming — the resumed session's prompt stays in effect.

--- a/test/summarizer-options.test.ts
+++ b/test/summarizer-options.test.ts
@@ -21,6 +21,16 @@ describe('buildSummarizerQueryOptions', () => {
     expect(opts.persistSession).toBe(false);
   });
 
+  it('sets settingSources: [] so the subprocess does not load ~/.claude hooks/settings that overflow the model context', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku' });
+    expect(opts.settingSources).toEqual([]);
+  });
+
+  it('sets settingSources: [] on the resume path too', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku', sessionId: 'abc-123' });
+    expect(opts.settingSources).toEqual([]);
+  });
+
   it('passes through the model and max_tokens', () => {
     const opts = buildSummarizerQueryOptions({ model: 'haiku' });
     expect(opts.model).toBe('haiku');


### PR DESCRIPTION
## Problem

`buildSummarizerQueryOptions` calls the Claude Agent SDK `query()` **without `settingSources`**. Per the SDK, an omitted `settingSources` loads **all** filesystem settings (CLI parity) — so the spawned summarizer subprocess loads the user's `~/.claude/settings.json` and fires every SessionStart / UserPromptSubmit hook they have configured.

For users with heavy hook configs, those hooks inject large context (rules files, `CLAUDE.md`, memory) that **overflows the summarizer model's context window before the conversation text is even added**. The API rejects it with HTTP 400 `"Prompt is too long"`, returned as a `result` message with `is_error: true` **but** `subtype: "success"`. `callClaude()` throws on the subtype (`summarizer.ts` — the `is_error` branch) **before** it reads `result`, so the real error text is discarded and the user sees only the opaque:

```
Summary generation failed: Summarizer SDK error: success
💡 All 5 summarization attempts failed.
  Check your API configuration (EPISODIC_MEMORY_API_BASE_URL / ANTHROPIC_API_KEY).
```

The suggested cause (API config) is a red herring — auth is fine. **Every** summary fails (`Summarized: 0`).

## Reproduction

Calling the exact SDK path (`model: haiku`, guard env) **without** `settingSources`, on a trivial "What is 2+2?" conversation, in an env with a substantial `~/.claude` hook config — the discarded result message:

```json
{ "subtype": "success", "is_error": true, "api_error_status": 400,
  "result": "Prompt is too long", "usage": { "input_tokens": 0 } }
```

~25 `hook_started` / `hook_response` system messages precede it — the subprocess fired the user's hooks. `input_tokens: 0` = rejected at validation. A trivial conversation still overflows, proving the bloat is the inherited config, not the conversation.

## Fix

Add `settingSources: []` to `buildSummarizerQueryOptions` (SDK isolation mode). Same repro with only that change:

```json
{ "subtype": "success", "is_error": false, "api_error_status": null,
  "result": "<summary>The user asked what 2+2 equals, and the agent answered 4.</summary>",
  "usage": { "input_tokens": 201 } }
```

Zero hooks fire; prompt drops from overflow to ~201 tokens; summary succeeds. Auth still works (it isolates settings/hooks/`CLAUDE.md`, not credentials). Applies on both the fresh and resume paths.

## Also fixes #106

`settingSources: []` stops **filesystem-defined MCP servers** from loading in the subprocess too — so the per-conversation MCP fleet described in #106 no longer spawns. Same root cause (subprocess inherits the user's full config), one fix.

Related: the `SummarizerSdkError('success')` re-queue/re-bill symptom in #103 — for heavy-config users the overflow is *why* that path is hit.

## Tests

`test/summarizer-options.test.ts` — two assertions that `settingSources` is `[]` on the fresh and resume paths. Full `summarizer-options` suite passes (27/27).

## Notes

Sibling to the existing `persistSession: false` (#83) and `tools: []` (#108) isolation options — this closes the remaining inheritance vector (settings + hooks). Filed from a downstream deployment that hit this (all summaries failing on a large multi-repo `~/.claude`).