### PR TITLE
fix(show): pin conversation timestamps to en-US/UTC

### DIFF
--- a/src/show.ts
+++ b/src/show.ts
@@ -84,7 +84,7 @@ export function formatConversationAsMarkdown(jsonl: string, startLine?: number, 
 
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
-    const timestamp = new Date(msg.timestamp).toLocaleString();
+    const timestamp = new Date(msg.timestamp).toLocaleString('en-US', { timeZone: 'UTC' });
     const messageId = msg.uuid || `msg-${i}`;
 
     // Skip user messages that are just tool results
@@ -299,7 +299,7 @@ export function formatConversationAsHTML(jsonl: string): string {
 
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
-    const timestamp = new Date(msg.timestamp).toLocaleString();
+    const timestamp = new Date(msg.timestamp).toLocaleString('en-US', { timeZone: 'UTC' });
     const messageId = `msg-${msg.uuid || i}`;
 
     // Skip user messages that are just tool results - they'll be rendered with their tool use
@@ -895,7 +895,7 @@ function formatCodexConversationAsMarkdown(lines: string[]): string {
       continue;
     }
 
-    const timestamp = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '';
+    const timestamp = entry.timestamp ? new Date(entry.timestamp).toLocaleString('en-US', { timeZone: 'UTC' }) : '';
     const anchor = payload.call_id || `msg-${i}`;
 
     if (payload.type === 'message') {

--- a/test/show.test.ts
+++ b/test/show.test.ts
@@ -182,8 +182,8 @@ describe('show command - markdown formatting', () => {
     expect(markdown).toMatch(/\*\*Agent\*\*/);
     expect(markdown).toContain('Looking at your instructions');
 
-    // Should show timestamps
-    expect(markdown).toMatch(/9\/19\/2025|2025-09-19/);
+    // Should show timestamps (pinned en-US/UTC in show.ts — see #120)
+    expect(markdown).toMatch(/9\/19\/2025/);
   });
 
   it('should include tool calls in the output', () => {


### PR DESCRIPTION
## Summary
- Pin `toLocaleString('en-US', { timeZone: 'UTC' })` for conversation timestamps in `show.ts` (markdown + HTML + Codex paths).
- Tighten `show.test.ts` to assert the stable `9/19/2025` form.

Fixes #120

## Test plan
- [x] Assertion matches pinned UTC formatting for the fixture timestamp
- [ ] `npx vitest run test/show.test.ts` on a non-US locale if available

Made with [Cursor](https://cursor.com)