### PR TITLE
fix(test): isolate vitest from real ~/.config/superpowers

### DIFF
--- a/test/setup-isolated-config.ts
+++ b/test/setup-isolated-config.ts
@@ -1,0 +1,15 @@
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * Isolate every test run from the developer's real ~/.config/superpowers.
+ * Without this, getSuperpowersDir()'s ensureDir side effect creates real dirs
+ * (and sometimes a real db.sqlite) when EPISODIC_MEMORY_CONFIG_DIR is unset.
+ * See https://github.com/obra/episodic-memory/issues/119
+ */
+const isolatedRoot = mkdtempSync(join(tmpdir(), 'episodic-memory-vitest-'));
+
+process.env.EPISODIC_MEMORY_CONFIG_DIR = join(isolatedRoot, 'superpowers');
+process.env.CLAUDE_CONFIG_DIR = join(isolatedRoot, 'claude');
+process.env.CODEX_HOME = join(isolatedRoot, 'codex');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    setupFiles: ['test/setup-isolated-config.ts'],
     testTimeout: 30000, // 30 seconds for embedding/indexing tests
   },
 });


### PR DESCRIPTION
## Summary
- Add `test/setup-isolated-config.ts` that sets `EPISODIC_MEMORY_CONFIG_DIR`, `CLAUDE_CONFIG_DIR`, and `CODEX_HOME` under a temp root.
- Register it via `setupFiles` in `vitest.config.ts`.

Fixes #119

## Test plan
- [ ] Run the suite and confirm no new files appear under `~/.config/superpowers`

Made with [Cursor](https://cursor.com)