### PR TITLE
fix: update hasMetadataFilters() to return true for date filters (#126)

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -51,7 +51,7 @@ function buildSearchFilters(options: SearchOptions): { sql: string; params: unkn
 }
 
 function hasMetadataFilters(options: SearchOptions): boolean {
-  return Boolean(options.project || options.session_id || options.git_branch);
+  return Boolean(options.project || options.session_id || options.git_branch || options.after || options.before);
 }
 
 const EXCHANGE_SELECT_COLUMNS = `

--- a/test/search-metadata-filters.test.ts
+++ b/test/search-metadata-filters.test.ts
@@ -176,4 +176,18 @@ describe('search metadata filters', () => {
     expect(projects.has('project-a')).toBe(true);
     expect(projects.has('project-b')).toBe(true);
   });
+
+  it('filters by after and before date filters in vector search mode (#126)', async () => {
+    const resultsAfter = await searchConversations('authentication', { after: '2026-01-02', mode: 'vector', limit: 10 });
+    expect(resultsAfter.length).toBeGreaterThan(0);
+    for (const r of resultsAfter) {
+      expect(new Date(r.exchange.timestamp) >= new Date('2026-01-02T00:00:00.000Z')).toBe(true);
+    }
+
+    const resultsBefore = await searchConversations('authentication', { before: '2026-01-02', mode: 'vector', limit: 10 });
+    expect(resultsBefore.length).toBeGreaterThan(0);
+    for (const r of resultsBefore) {
+      expect(new Date(r.exchange.timestamp) <= new Date('2026-01-02T23:59:59.999Z')).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
Fixes issue #126 where `hasMetadataFilters()` in `src/search.ts` did not return `true` when `filter.after` or `filter.before` date options were specified.

When date filters are used without project/session/branch filters, vector search previously set `k = limit` instead of expanding to `k = limit * 3`. Because `sqlite-vec` applies KNN before the `WHERE` timestamp filter clause, candidates outside the top `limit` were excluded before date filtering was applied, causing missing or empty search results.

## Changes
- Updated `hasMetadataFilters()` in `src/search.ts` to check `options.after` and `options.before`.
- Added test coverage in `test/search-metadata-filters.test.ts` for vector search with date range filters.

## Verification
- Ran `npx vitest run test/search-metadata-filters.test.ts` (all 8 tests passed).

## AI Disclosure
This change was implemented with assistance from AI (Claude Code / Antigravity Agent).

Closes #126