### PR TITLE
fix: degrade gracefully when the embedding backend can't load (#135)

### DIFF
--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,9 +1,4 @@
-import { pipeline, FeatureExtractionPipeline, env } from '@huggingface/transformers';
-
-// Disable progress callbacks to prevent stdout pollution in MCP context
-// In MCP, stdout is reserved for JSON-RPC communication.
-env.allowLocalModels = true;
-env.useBrowserCache = false;
+import type { FeatureExtractionPipeline } from '@huggingface/transformers';
 
 /**
  * Embedding model configuration.
@@ -23,16 +18,54 @@ export const BGE_QUERY_PREFIX = 'Represent this sentence for searching relevant 
 
 let embeddingPipeline: FeatureExtractionPipeline | null = null;
 
-export async function initEmbeddings(): Promise<void> {
-  if (!embeddingPipeline) {
-    console.error('Loading embedding model (first run may take time)...');
-    embeddingPipeline = await pipeline(
-      'feature-extraction',
-      MODEL_ID,
-      { dtype: MODEL_DTYPE, progress_callback: () => {} }
-    );
-    console.error('Embedding model loaded');
+/**
+ * Thrown when the embedding backend can't be loaded. The most common cause is
+ * that `@huggingface/transformers` eagerly requires `sharp`, whose native
+ * binding fails to `dlopen` libvips on some hosts (#135) — even though sharp is
+ * only needed for image inputs, not the text feature-extraction this package
+ * uses. Callers that can proceed without semantic features (e.g. background
+ * sync indexing) should catch this and degrade gracefully rather than crash.
+ */
+export class EmbeddingsUnavailableError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'EmbeddingsUnavailableError';
   }
+}
+
+export async function initEmbeddings(): Promise<void> {
+  if (embeddingPipeline) return;
+
+  // Load @huggingface/transformers lazily. Its module graph eagerly requires
+  // `sharp`, so a static top-level import would crash *every* consumer of this
+  // file at import time on hosts where sharp's native binding can't load —
+  // including code paths that never embed anything. Importing here keeps the
+  // failure catchable and confined to callers that actually need embeddings.
+  let pipeline: typeof import('@huggingface/transformers').pipeline;
+  try {
+    const transformers = await import('@huggingface/transformers');
+    // Disable progress callbacks / remote cache to prevent stdout pollution in
+    // MCP context, where stdout is reserved for JSON-RPC communication.
+    transformers.env.allowLocalModels = true;
+    transformers.env.useBrowserCache = false;
+    pipeline = transformers.pipeline;
+  } catch (error) {
+    throw new EmbeddingsUnavailableError(
+      'Failed to load the embedding backend (@huggingface/transformers). This ' +
+      'usually means the native "sharp" binding could not load libvips; ' +
+      'semantic search and indexing are unavailable until it is fixed. ' +
+      `Underlying error: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error }
+    );
+  }
+
+  console.error('Loading embedding model (first run may take time)...');
+  embeddingPipeline = await pipeline(
+    'feature-extraction',
+    MODEL_ID,
+    { dtype: MODEL_DTYPE, progress_callback: () => {} }
+  );
+  console.error('Embedding model loaded');
 }
 
 export async function generateEmbedding(text: string): Promise<number[]> {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -144,43 +144,68 @@ export async function syncConversations(
 
   // Index copied files (unless skipIndex is set)
   if (!options.skipIndex && filesToIndex.length > 0) {
-    const { initDatabase, insertExchange } = await import('./db.js');
-    const { initEmbeddings, generateExchangeEmbedding } = await import('./embeddings.js');
     const { parseConversation } = await import('./parser.js');
 
-    const db = initDatabase();
-    await initEmbeddings();
-
-    for (const file of filesToIndex) {
-      try {
-        // Check for DO NOT INDEX marker
-        if (shouldSkipConversation(file)) {
-          continue; // Skip indexing but file is already copied
-        }
-
-        const project = path.basename(path.dirname(file));
-        const exchanges = await parseConversation(file, project, file);
-
-        for (const exchange of exchanges) {
-          const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
-          const embedding = await generateExchangeEmbedding(
-            exchange.userMessage,
-            exchange.assistantMessage,
-            toolNames
-          );
-          insertExchange(db, exchange, embedding, toolNames);
-        }
-
-        result.indexed++;
-      } catch (error) {
-        result.errors.push({
-          file,
-          error: error instanceof Error ? error.message : String(error)
-        });
-      }
+    // Load the embedding backend first. It can fail on hosts where sharp's
+    // native binding (pulled in transitively by @huggingface/transformers)
+    // can't dlopen libvips (#135). That must not abort the whole sync — copying
+    // has already happened and summaries still need to run — so surface a
+    // clear, actionable error and skip semantic indexing for this run instead
+    // of throwing out of syncConversations (which would crash the SessionStart
+    // hook that invokes it).
+    let embeddings: typeof import('./embeddings.js') | null = null;
+    try {
+      embeddings = await import('./embeddings.js');
+      await embeddings.initEmbeddings();
+    } catch (error) {
+      embeddings = null;
+      result.errors.push({
+        file: '(embeddings)',
+        error: `Semantic indexing skipped — embedding backend unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      console.error(
+        'episodic-memory: embedding backend failed to load; skipping semantic ' +
+        'indexing this run (copying and summaries still run). See the error above.'
+      );
     }
 
-    db.close();
+    if (embeddings) {
+      const { initDatabase, insertExchange } = await import('./db.js');
+      const { generateExchangeEmbedding } = embeddings;
+
+      const db = initDatabase();
+
+      for (const file of filesToIndex) {
+        try {
+          // Check for DO NOT INDEX marker
+          if (shouldSkipConversation(file)) {
+            continue; // Skip indexing but file is already copied
+          }
+
+          const project = path.basename(path.dirname(file));
+          const exchanges = await parseConversation(file, project, file);
+
+          for (const exchange of exchanges) {
+            const toolNames = exchange.toolCalls?.map(tc => tc.toolName);
+            const embedding = await generateExchangeEmbedding(
+              exchange.userMessage,
+              exchange.assistantMessage,
+              toolNames
+            );
+            insertExchange(db, exchange, embedding, toolNames);
+          }
+
+          result.indexed++;
+        } catch (error) {
+          result.errors.push({
+            file,
+            error: error instanceof Error ? error.message : String(error)
+          });
+        }
+      }
+
+      db.close();
+    }
   }
 
   // Generate summaries for files that need them

--- a/test/embeddings-unavailable.test.ts
+++ b/test/embeddings-unavailable.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Simulate the real-world failure: @huggingface/transformers eagerly requires
+// `sharp`, and on hosts where sharp's native binding can't dlopen libvips the
+// module blows up (#135). Throwing getters reproduce that — importing the
+// module succeeds, but the first property access inside initEmbeddings raises
+// the native error, which initEmbeddings must convert into a typed error while
+// preserving the underlying cause. (A factory that throws at module eval is
+// intercepted and re-messaged by vitest, so a getter models it more faithfully.)
+vi.mock('@huggingface/transformers', () => {
+  const boom = () => {
+    throw new Error('ERR_DLOPEN_FAILED: libvips-cpp.so.8.17.3: cannot open shared object file');
+  };
+  return {
+    get env() { return boom(); },
+    get pipeline() { return boom(); },
+  };
+});
+
+import { initEmbeddings, EmbeddingsUnavailableError } from '../src/embeddings.js';
+
+describe('embeddings — backend load failure (#135)', () => {
+  it('initEmbeddings rejects with EmbeddingsUnavailableError instead of an opaque native crash', async () => {
+    await expect(initEmbeddings()).rejects.toBeInstanceOf(EmbeddingsUnavailableError);
+  });
+
+  it('the error is actionable (mentions the likely cause) and preserves the underlying cause', async () => {
+    let caught: unknown;
+    try {
+      await initEmbeddings();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(EmbeddingsUnavailableError);
+    const err = caught as EmbeddingsUnavailableError;
+    expect(err.message).toMatch(/sharp|libvips|transformers/i);
+    expect(err.message).toMatch(/libvips-cpp\.so/);
+    expect((err as any).cause).toBeInstanceOf(Error);
+  });
+});

--- a/test/sync-embeddings-unavailable.test.ts
+++ b/test/sync-embeddings-unavailable.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock the embeddings module so `initEmbeddings` fails the way it does on a host
+// where sharp's native binding can't dlopen libvips (#135). sync.ts loads it via
+// `await import('./embeddings.js')`, which vi.mock intercepts when registered
+// before sync is loaded. A full factory replacement also keeps the real
+// @huggingface/transformers / sharp out of the test entirely.
+vi.mock('../src/embeddings.js', () => ({
+  initEmbeddings: vi.fn().mockRejectedValue(
+    new Error(
+      'Failed to load the embedding backend (@huggingface/transformers). ' +
+      'ERR_DLOPEN_FAILED: libvips-cpp.so.8.17.3: cannot open shared object file'
+    )
+  ),
+  generateExchangeEmbedding: vi.fn(),
+  generateQueryEmbedding: vi.fn(),
+  generateEmbedding: vi.fn(),
+  initEmbeddingsFailed: false,
+}));
+
+import { syncConversations } from '../src/sync.js';
+
+function makeNonEmptyJsonl(sessionId: string): string {
+  return [
+    JSON.stringify({
+      type: 'user',
+      uuid: `${sessionId}-user-1`,
+      parentUuid: null,
+      timestamp: '2025-10-01T12:00:00Z',
+      isSidechain: false,
+      cwd: '/tmp/test-cwd',
+      message: { role: 'user', content: 'What does the deploy script do?' },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      uuid: `${sessionId}-asst-1`,
+      parentUuid: `${sessionId}-user-1`,
+      timestamp: '2025-10-01T12:00:01Z',
+      isSidechain: false,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'It deploys to prod via terraform apply.' }] },
+    }),
+  ].join('\n');
+}
+
+describe('sync command — embedding backend unavailable (#135)', () => {
+  let testDir: string;
+  let sourceDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'episodic-memory-embeddings-unavailable-'));
+    sourceDir = join(testDir, 'source');
+    destDir = join(testDir, 'dest');
+    mkdirSync(sourceDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try { rmSync(testDir, { recursive: true, force: true }); } catch {}
+  });
+
+  it('does not throw when the embedding backend fails to load — copies the file, skips indexing, records a clear error', async () => {
+    mkdirSync(join(sourceDir, 'project-a'), { recursive: true });
+    const sessionId = '019aff97-5651-71e0-80ec-b4f2c51095c3';
+    writeFileSync(join(sourceDir, 'project-a', `${sessionId}.jsonl`), makeNonEmptyJsonl(sessionId), 'utf-8');
+
+    // Must resolve (not reject): a failed embedder previously threw out of
+    // syncConversations and crashed the SessionStart hook that calls it.
+    const result = await syncConversations(sourceDir, destDir, { skipSummaries: true });
+
+    // Copying still happened — degradation is partial, not total.
+    expect(result.copied).toBe(1);
+    expect(existsSync(join(destDir, 'project-a', `${sessionId}.jsonl`))).toBe(true);
+
+    // Nothing was indexed, because there is no embedder.
+    expect(result.indexed).toBe(0);
+
+    // The failure is surfaced (not swallowed), with an actionable message.
+    const embErr = result.errors.find(e => e.file === '(embeddings)');
+    expect(embErr).toBeDefined();
+    expect(embErr!.error).toMatch(/embedding backend unavailable/i);
+    expect(embErr!.error).toMatch(/libvips|sharp|transformers/i);
+  });
+});


### PR DESCRIPTION
## What & why

Fixes #135. On hosts where `sharp`'s native binding can't `dlopen` libvips, `@huggingface/transformers` (which pulls in sharp transitively) throws at load. Because `src/embeddings.ts` imported transformers at the **top level**, that failure crashed *every* consumer at import time — including the `SessionStart` `sync --background` hook, which exited 1 with a raw stack trace and silently stopped background sync.

Note that `cli/install-check.js` already documents sharp as an optional/OS-specific external ("missing those is OK"), but the runtime path did not honor that contract. This PR makes it real: a missing/broken sharp degrades semantic features instead of taking the process down.

## Changes

- **`src/embeddings.ts`** — load `@huggingface/transformers` lazily inside `initEmbeddings()` (via dynamic `import()`), wrapped in try/catch. On failure it throws a typed **`EmbeddingsUnavailableError`** (with `cause`). Merely importing `embeddings.ts` no longer touches sharp; the failure is now catchable and confined to callers that actually embed. The `env.allowLocalModels` / `env.useBrowserCache` config moves into the lazy init (still applied before the first `pipeline()` call).
- **`src/sync.ts`** — in the indexing block, catch an embedding-backend load failure, push a clear actionable entry to `result.errors`, log a one-line diagnostic to stderr, and **skip semantic indexing for that run** instead of throwing out of `syncConversations`. Copying and summaries still complete.

The failure stays **visible** (stderr + `result.errors`) — this is not error-hiding (cf. #94); it just no longer crashes the whole sync. The embedding-migration phase in `sync-cli.ts` was already wrapped in try/catch, so it benefits automatically once the import is lazy.

Out of scope: `search.ts` / `indexer.ts` still call `initEmbeddings()` without a catch, so on an affected host those commands now surface a clean typed `EmbeddingsUnavailableError` instead of a crash-at-import — happy to add fallback-to-FTS there in a follow-up if you'd like.

## Testing

- `test/embeddings-unavailable.test.ts` — `initEmbeddings()` rejects with `EmbeddingsUnavailableError` (typed, actionable, preserves cause) when the transformers load fails.
- `test/sync-embeddings-unavailable.test.ts` — `syncConversations` **resolves** (does not throw) when the embedder can't load: the file is still copied, `indexed === 0`, and a clear `(embeddings)` error is recorded.
- Full suite: `tsc --noEmit` clean; **209/210 tests pass**. The single failure (`test/show.test.ts` markdown formatting) reproduces on unmodified `main` and is unrelated to this change.

🤖 Prepared with Claude Code