### PR TITLE
fix: skip dangling project symlinks instead of aborting directory walks

### DIFF
--- a/src/index-cli.ts
+++ b/src/index-cli.ts
@@ -2,7 +2,7 @@
 import { verifyIndex, repairIndex } from './verify.js';
 import { indexSession, indexUnprocessed, indexConversations } from './indexer.js';
 import { initDatabase } from './db.js';
-import { getDbPath, getArchiveDir } from './paths.js';
+import { getDbPath, getArchiveDir, statIfExists } from './paths.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -92,7 +92,7 @@ async function main() {
           const projects = fs.readdirSync(archiveDir);
           for (const project of projects) {
             const projectPath = path.join(archiveDir, project);
-            if (!fs.statSync(projectPath).isDirectory()) continue;
+            if (!statIfExists(projectPath)?.isDirectory()) continue;
 
             const summaries = fs.readdirSync(projectPath).filter(f => f.endsWith('-summary.txt'));
             for (const summary of summaries) {

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -6,7 +6,7 @@ import { parseConversation } from './parser.js';
 import { initEmbeddings, generateExchangeEmbedding } from './embeddings.js';
 import { summarizeConversation } from './summarizer.js';
 import { ConversationExchange } from './types.js';
-import { getArchiveDir, getExcludedProjects, getConversationSourceDirs, findJsonlFiles } from './paths.js';
+import { getArchiveDir, getExcludedProjects, getConversationSourceDirs, findJsonlFiles, statIfExists } from './paths.js';
 import { formatErrorSentinel, shouldQueueForSummary } from './summary-sentinel.js';
 
 // Set max output tokens for Claude SDK (used by summarizer)
@@ -76,9 +76,9 @@ export async function indexConversations(
     // Skip if limiting to specific project
     if (limitToProject && project !== limitToProject) continue;
     const projectPath = path.join(sourceDir, project);
-    const stat = fs.statSync(projectPath);
+    const stat = statIfExists(projectPath);
 
-    if (!stat.isDirectory()) continue;
+    if (!stat?.isDirectory()) continue;
 
     const files = findJsonlFiles(projectPath, excludedDirSet);
 
@@ -204,7 +204,7 @@ export async function indexSession(sessionId: string, concurrency: number = 1, n
     if (excludedProjects.includes(project)) continue;
 
     const projectPath = path.join(sourceDir, project);
-    if (!fs.statSync(projectPath).isDirectory()) continue;
+    if (!statIfExists(projectPath)?.isDirectory()) continue;
 
     const files = findJsonlFiles(projectPath, excludedDirSet).filter(f => f.includes(sessionId));
 
@@ -304,7 +304,7 @@ export async function indexUnprocessed(concurrency: number = 1, noSummaries: boo
     if (excludedProjects.includes(project)) continue;
 
     const projectPath = path.join(sourceDir, project);
-    if (!fs.statSync(projectPath).isDirectory()) continue;
+    if (!statIfExists(projectPath)?.isDirectory()) continue;
 
     const files = findJsonlFiles(projectPath, excludedDirSet);
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -80,6 +80,20 @@ export function findJsonlFiles(dir: string, excludedDirNames?: ReadonlySet<strin
 }
 
 /**
+ * statSync that follows symlinks but returns null instead of throwing when
+ * the entry cannot be stat'ed — a dangling symlink (e.g. left behind by a
+ * storage migration), or an entry deleted between readdir and stat.
+ * Callers treat null as "skip this entry".
+ */
+export function statIfExists(target: string): fs.Stats | null {
+  try {
+    return fs.statSync(target);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Get the personal superpowers directory
  *
  * Precedence:

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { SUMMARIZER_CONTEXT_MARKER } from './constants.js';
-import { getExcludedProjects, findJsonlFiles } from './paths.js';
+import { getExcludedProjects, findJsonlFiles, statIfExists } from './paths.js';
 import { formatErrorSentinel, shouldQueueForSummary } from './summary-sentinel.js';
 
 const EXCLUSION_MARKERS = [
@@ -102,9 +102,9 @@ export async function syncConversations(
     }
 
     const projectPath = path.join(sourceDir, project);
-    const stat = fs.statSync(projectPath);
+    const stat = statIfExists(projectPath);
 
-    if (!stat.isDirectory()) continue;
+    if (!stat?.isDirectory()) continue;
 
     const files = findJsonlFiles(projectPath, excludedDirSet);
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { parseConversation } from './parser.js';
 import { initDatabase, getAllExchanges, getFileLastIndexed } from './db.js';
-import { getArchiveDir, getExcludedProjects, findJsonlFiles } from './paths.js';
+import { getArchiveDir, getExcludedProjects, findJsonlFiles, statIfExists } from './paths.js';
 import { isErroredSentinel } from './summary-sentinel.js';
 
 export interface VerificationResult {
@@ -45,9 +45,9 @@ export async function verifyIndex(): Promise<VerificationResult> {
     }
 
     const projectPath = path.join(archiveDir, project);
-    const stat = fs.statSync(projectPath);
+    const stat = statIfExists(projectPath);
 
-    if (!stat.isDirectory()) continue;
+    if (!stat?.isDirectory()) continue;
 
     const files = findJsonlFiles(projectPath, excludedDirSet);
 

--- a/test/dangling-symlink.test.ts
+++ b/test/dangling-symlink.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import { syncConversations } from '../src/sync.js';
+import { indexConversations, indexUnprocessed, indexSession } from '../src/indexer.js';
+import { verifyIndex } from '../src/verify.js';
+import { statIfExists } from '../src/paths.js';
+import { suppressConsole } from './test-utils.js';
+
+// Symlink creation is unavailable in some environments (e.g. Windows without
+// Developer Mode). Probe once and skip the whole suite when unsupported.
+let symlinksSupported = true;
+{
+  const probeDir = mkdtempSync(join(tmpdir(), 'em-symlink-probe-'));
+  try {
+    symlinkSync(join(probeDir, 'no-such-target'), join(probeDir, 'probe'));
+  } catch {
+    symlinksSupported = false;
+  }
+  rmSync(probeDir, { recursive: true, force: true });
+}
+
+/**
+ * Synthesize one user/assistant exchange's worth of JSONL lines.
+ * Same shape as Claude Code transcripts so the parser accepts them.
+ */
+function makeExchangeLines(seq: number, sessionId: string): string {
+  const userUuid = `user-${seq}-${sessionId}`;
+  const assistantUuid = `asst-${seq}-${sessionId}`;
+  const ts = new Date(2026, 0, 1 + seq).toISOString();
+  const userLine = JSON.stringify({
+    parentUuid: null,
+    isSidechain: false,
+    userType: 'external',
+    cwd: '/test/project',
+    sessionId,
+    version: '2.0.9',
+    gitBranch: 'main',
+    type: 'user',
+    message: { role: 'user', content: `User question ${seq} in session ${sessionId}` },
+    uuid: userUuid,
+    timestamp: ts,
+  });
+  const assistantLine = JSON.stringify({
+    parentUuid: userUuid,
+    isSidechain: false,
+    userType: 'external',
+    cwd: '/test/project',
+    sessionId,
+    version: '2.0.9',
+    gitBranch: 'main',
+    type: 'assistant',
+    message: {
+      model: 'claude-sonnet-4-5',
+      role: 'assistant',
+      content: [{ type: 'text', text: `Reply ${seq} in session ${sessionId}` }],
+    },
+    uuid: assistantUuid,
+    timestamp: ts,
+  });
+  return userLine + '\n' + assistantLine + '\n';
+}
+
+describe.skipIf(!symlinksSupported)('directory walks survive dangling symlinks', () => {
+  let testDir: string;
+  let projectsDir: string;
+  let archiveDir: string;
+  let configDir: string;
+  let dbPath: string;
+  let restoreConsole: () => void;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'em-dangling-test-'));
+    projectsDir = join(testDir, 'projects');
+    archiveDir = join(testDir, 'archive');
+    configDir = join(testDir, 'config');
+    dbPath = join(testDir, 'test.db');
+    mkdirSync(projectsDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+
+    process.env.TEST_PROJECTS_DIR = projectsDir;
+    process.env.TEST_ARCHIVE_DIR = archiveDir;
+    process.env.EPISODIC_MEMORY_CONFIG_DIR = configDir;
+    process.env.TEST_DB_PATH = dbPath;
+    restoreConsole = suppressConsole();
+  });
+
+  afterEach(() => {
+    restoreConsole();
+    delete process.env.TEST_PROJECTS_DIR;
+    delete process.env.TEST_ARCHIVE_DIR;
+    delete process.env.EPISODIC_MEMORY_CONFIG_DIR;
+    delete process.env.TEST_DB_PATH;
+    try { rmSync(testDir, { recursive: true, force: true }); } catch {}
+  });
+
+  /** A normal on-disk project with one parseable conversation. */
+  function setupRealProject(sessionId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'): void {
+    const projectDir = join(projectsDir, '-Users-real-project');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, `${sessionId}.jsonl`), makeExchangeLines(1, sessionId), 'utf-8');
+  }
+
+  /** A symlink whose target no longer exists — what a storage migration leaves behind. */
+  function addDanglingSymlink(parentDir: string): void {
+    symlinkSync(join(testDir, 'no-such-target'), join(parentDir, '-Users-migrated-away'));
+  }
+
+  function indexedArchivePaths(): string[] {
+    const db = new Database(dbPath);
+    const rows = db.prepare('SELECT DISTINCT archive_path FROM exchanges').all() as Array<{ archive_path: string }>;
+    db.close();
+    return rows.map(r => r.archive_path);
+  }
+
+  it('sync copies real and valid-symlinked projects and skips the dangling entry', async () => {
+    setupRealProject();
+
+    // A project reachable only through a healthy symlink must still sync —
+    // the fix has to skip dangling links without breaking valid ones.
+    const movedProject = join(testDir, 'moved-project');
+    mkdirSync(movedProject, { recursive: true });
+    writeFileSync(
+      join(movedProject, 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff.jsonl'),
+      makeExchangeLines(2, 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff'),
+      'utf-8'
+    );
+    symlinkSync(movedProject, join(projectsDir, '-Users-valid-link'));
+
+    addDanglingSymlink(projectsDir);
+
+    const result = await syncConversations(projectsDir, archiveDir, { skipIndex: true, skipSummaries: true });
+
+    expect(result.copied).toBe(2);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('indexConversations indexes the real project despite a dangling sibling', async () => {
+    setupRealProject();
+    addDanglingSymlink(projectsDir);
+
+    await indexConversations(undefined, undefined, 1, true);
+
+    const paths = indexedArchivePaths();
+    expect(paths.some(p => p.includes('-Users-real-project'))).toBe(true);
+  });
+
+  it('indexUnprocessed indexes the real project despite a dangling sibling', async () => {
+    setupRealProject();
+    addDanglingSymlink(projectsDir);
+
+    await indexUnprocessed(1, true);
+
+    const paths = indexedArchivePaths();
+    expect(paths.some(p => p.includes('-Users-real-project'))).toBe(true);
+  });
+
+  it('indexSession completes a not-found scan without aborting', async () => {
+    setupRealProject();
+    addDanglingSymlink(projectsDir);
+
+    await expect(
+      indexSession('ffffffff-0000-0000-0000-000000000000', 1, true)
+    ).resolves.toBeUndefined();
+  });
+
+  it('verifyIndex walks an archive containing a dangling symlink', async () => {
+    const archiveProject = join(archiveDir, '-Users-real-project');
+    mkdirSync(archiveProject, { recursive: true });
+    writeFileSync(
+      join(archiveProject, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'),
+      makeExchangeLines(1, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+      'utf-8'
+    );
+    addDanglingSymlink(archiveDir);
+
+    const result = await verifyIndex();
+
+    // The walk must reach the real project (its conversation has no summary yet).
+    expect(result.missing.length).toBe(1);
+  });
+});
+
+describe.skipIf(!symlinksSupported)('statIfExists', () => {
+  it('follows valid symlinks and returns null for dangling ones', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'em-statifexists-'));
+    try {
+      const realDir = join(dir, 'real');
+      mkdirSync(realDir);
+      symlinkSync(realDir, join(dir, 'valid-link'));
+      symlinkSync(join(dir, 'no-such-target'), join(dir, 'dangling-link'));
+
+      expect(statIfExists(realDir)?.isDirectory()).toBe(true);
+      expect(statIfExists(join(dir, 'valid-link'))?.isDirectory()).toBe(true);
+      expect(statIfExists(join(dir, 'dangling-link'))).toBeNull();
+      expect(statIfExists(join(dir, 'never-existed'))).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #142

## Problem

A dangling symlink in `~/.claude/projects` (for example, left behind by a storage migration) crashes every walker that stats `readdirSync` entries: `syncConversations`, `indexConversations`, `indexSession`, `indexUnprocessed`, `verifyIndex`, and the `rebuild` summary-deletion walk all die with `ENOENT` before processing any remaining project. Since sync runs on SessionStart, one stale symlink takes episodic memory fully down.

```
Error: ENOENT: no such file or directory, stat '.../projects/migrated-away'
    at Object.statSync (node:fs:1746:25)
    at syncConversations (.../dist/sync.js:76:25)
```

Same failure family as #121 / #132 (transcripts vanishing mid-run), one directory level up.

## Fix

Add `statIfExists()` to `paths.ts` — a `statSync` that returns `null` instead of throwing when the entry can't be stat'ed — and use it at all six walk sites:

```ts
const stat = statIfExists(projectPath);
if (!stat?.isDirectory()) continue;
```

Design notes:

- **Valid symlinks keep working.** The helper keeps `statSync` follow semantics (not `lstat`), so symlinked project directories are still traversed; only entries whose target is gone are skipped. The new sync test asserts a valid-symlinked project still syncs.
- **Skip is silent**, matching the existing silent skip of non-directory entries one line down. Happy to add a log line if you'd prefer these surfaced.
- An entry deleted between `readdir` and `stat` (the #121-style race, at the project level) is covered by the same guard.

## Tests

New `test/dangling-symlink.test.ts` (follows the `exclude-nested.test.ts` isolation pattern):

- sync copies a real project **and** a valid-symlinked project while skipping a dangling sibling (`copied === 2`, no errors)
- `indexConversations` / `indexUnprocessed` index the real project despite a dangling sibling
- `indexSession` completes a not-found scan without aborting
- `verifyIndex` walks an archive containing a dangling symlink
- `statIfExists` unit: real dir / valid symlink → `Stats`, dangling symlink / missing path → `null`
- the whole suite `describe.skipIf`s on platforms where symlink creation is unavailable (Windows without Developer Mode)

All six tests fail with the exact production `ENOENT` (or missing helper) before the fix and pass after.

Full suite: 212/213 passing locally. The one failure, `test/verify.test.ts > repairIndex > re-indexes outdated files during repair`, is a pre-existing same-millisecond flake — it fails identically on a clean `main` checkout on a fast machine (`expected 1785529540716 to be greater than 1785529540716`). Happy to file it separately.

## Repro

```bash
mkdir -p /tmp/em-repro/projects/real-project /tmp/em-repro/archive
printf '{"type":"user","message":{"role":"user","content":"hello"}}\n' \
  > /tmp/em-repro/projects/real-project/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl
ln -s /nonexistent-target /tmp/em-repro/projects/migrated-away

node --input-type=module -e "
import { syncConversations } from './dist/sync.js';
console.log(await syncConversations('/tmp/em-repro/projects', '/tmp/em-repro/archive', { skipIndex: true, skipSummaries: true }));
"
```

Before: `ENOENT` crash, nothing synced. After: `{ copied: 1, skipped: 0, indexed: 0, summarized: 0, errors: [] }`.

`dist/` is untouched per repo convention (regenerated at release); `npm run build` compiles clean with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
