### PR TITLE
fix: fall back to transcript summarization when the resume subprocess exits nonzero

### DIFF
--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -31,6 +31,17 @@ export function isResumeFailure(error: unknown): boolean {
   return error instanceof SummarizerSdkError && error.subtype === 'error_during_execution';
 }
 
+/**
+ * True when the SDK's spawned Claude Code subprocess died before returning a
+ * result (e.g. `--resume` exiting 1 because the session is a background agent
+ * that can't be resumed without --fork-session). The SDK throws these as plain
+ * Errors, not SummarizerSdkError, so isResumeFailure never matches them —
+ * callers that resumed a session should fall back to the non-resume path.
+ */
+export function isProcessExitFailure(error: unknown): boolean {
+  return error instanceof Error && /exited with code|terminated by signal/.test(error.message);
+}
+
 export interface CodexSummarizerCommand {
   command: string;
   args: string[];
@@ -174,29 +185,42 @@ async function callClaude(prompt: string, sessionId?: string, useFallback = fals
   const fallbackModel = process.env.EPISODIC_MEMORY_API_MODEL_FALLBACK || 'sonnet';
   const model = useFallback ? fallbackModel : primaryModel;
 
-  for await (const message of query({
-    prompt,
-    options: buildSummarizerQueryOptions({ model, sessionId, cwd }) as any,
-  })) {
-    if (message && typeof message === 'object' && 'type' in message && message.type === 'result') {
-      // Throw on is_error — otherwise we return `message.result` (undefined) and the SDK's later iterator throw never fires.
-      if ((message as any).is_error) {
-        throw new SummarizerSdkError((message as any).subtype || 'unknown', (message as any).session_id);
-      }
-      const result = (message as any).result;
-
-      // Check if result is an API error (SDK returns errors as result strings)
-      if (typeof result === 'string' && result.includes('API Error') && result.includes('thinking.budget_tokens')) {
-        if (!useFallback) {
-          console.log(`    ${primaryModel} hit thinking budget error, retrying with ${fallbackModel}`);
-          return await callClaude(prompt, sessionId, true, cwd);
+  // Buffer the subprocess's stderr — without it a crash surfaces only as
+  // "exited with code 1" and the real cause (e.g. bg-agent resume refusal) is lost.
+  let stderrTail = '';
+  try {
+    for await (const message of query({
+      prompt,
+      options: {
+        ...buildSummarizerQueryOptions({ model, sessionId, cwd }),
+        stderr: (data: string) => { stderrTail = (stderrTail + data).slice(-2000); },
+      } as any,
+    })) {
+      if (message && typeof message === 'object' && 'type' in message && message.type === 'result') {
+        // Throw on is_error — otherwise we return `message.result` (undefined) and the SDK's later iterator throw never fires.
+        if ((message as any).is_error) {
+          throw new SummarizerSdkError((message as any).subtype || 'unknown', (message as any).session_id);
         }
-        // If fallback also fails, return error message
+        const result = (message as any).result;
+
+        // Check if result is an API error (SDK returns errors as result strings)
+        if (typeof result === 'string' && result.includes('API Error') && result.includes('thinking.budget_tokens')) {
+          if (!useFallback) {
+            console.log(`    ${primaryModel} hit thinking budget error, retrying with ${fallbackModel}`);
+            return await callClaude(prompt, sessionId, true, cwd);
+          }
+          // If fallback also fails, return error message
+          return result;
+        }
+
         return result;
       }
-
-      return result;
     }
+  } catch (error) {
+    if (error instanceof Error && stderrTail.trim() && isProcessExitFailure(error)) {
+      error.message = `${error.message}: ${stderrTail.trim()}`;
+    }
+    throw error;
   }
   return '';
 }
@@ -520,8 +544,11 @@ ${conversationText}`;
       const result = await callClaude(prompt, claudeSessionId, false, cwd);
       return extractSummary(result);
     } catch (error) {
-      // Resume fails when the session's cwd doesn't exist on disk — retry without resume and feed the conversation text directly.
-      if (claudeSessionId && isResumeFailure(error)) {
+      // Resume can fail for reasons the transcript path doesn't care about: the
+      // session's cwd no longer exists, or the subprocess refuses to resume
+      // (bg-agent sessions exit 1 without --fork-session). Retry without resume
+      // and feed the conversation text directly.
+      if (claudeSessionId && (isResumeFailure(error) || isProcessExitFailure(error))) {
         console.log(`    resume failed for ${claudeSessionId} (${(error as Error).message}); retrying without resume`);
         const fullPrompt = prompt + '\n\n' + formatConversationText(exchanges);
         const result = await callClaude(fullPrompt);

--- a/test/summarizer-resume-fallback.test.ts
+++ b/test/summarizer-resume-fallback.test.ts
@@ -132,6 +132,49 @@ describe('summarizeConversation — Claude resume fallback (cwd-mismatch recover
     expect(opts.resume).toBe('abc-123');
   });
 
+  it('retries without resume when the subprocess exits nonzero (e.g. bg-agent session refuses --resume)', async () => {
+    // `claude --resume` exits 1 for sessions registered as background agents
+    // ("add --fork-session to branch off a copy"). The SDK surfaces that as a
+    // plain Error, not an is_error result — the fallback must still fire.
+    vi.mocked(query)
+      .mockImplementationOnce(() => {
+        throw new Error('Claude Code process exited with code 1');
+      })
+      .mockReturnValueOnce(asyncIterableFor([
+        { type: 'result', is_error: false, result: '<summary>Recovered from bg-agent refusal.</summary>' },
+      ]) as any);
+
+    const result = await summarizeConversation([makeExchange()], 'abc-123');
+    expect(result).toBe('Recovered from bg-agent refusal.');
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(2);
+
+    const secondCallOptions = vi.mocked(query).mock.calls[1][0].options as any;
+    expect(secondCallOptions.resume).toBeUndefined();
+    const secondPrompt = vi.mocked(query).mock.calls[1][0].prompt as string;
+    expect(secondPrompt).toContain('How do I rebase against origin/main?');
+  });
+
+  it('appends the subprocess stderr to process-exit errors so sentinels record the real cause', async () => {
+    const stderrText = 'Error: Session abc-123 is currently running as a background agent (bg).';
+    const failWithStderr = (args: any) => {
+      (args.options as any).stderr?.(stderrText);
+      return {
+        [Symbol.asyncIterator]() {
+          return { next: () => Promise.reject(new Error('Claude Code process exited with code 1')) };
+        },
+      };
+    };
+    // Both the resume attempt and the fallback die, so the surfaced error is
+    // the fallback's — which must carry the captured stderr.
+    vi.mocked(query)
+      .mockImplementationOnce(failWithStderr as any)
+      .mockImplementationOnce(failWithStderr as any);
+
+    await expect(summarizeConversation([makeExchange()], 'abc-123'))
+      .rejects.toThrow(/background agent/);
+    expect(vi.mocked(query)).toHaveBeenCalledTimes(2);
+  });
+
   it('does not retry when the SDK throws a non-resume error', async () => {
     vi.mocked(query).mockImplementationOnce(() => {
       throw new Error('Network unreachable');


### PR DESCRIPTION
Fixes #146.

- Add `isProcessExitFailure()` — matches the SDK's plain-`Error` throws (`exited with code` / `terminated by signal`) — and include it in the retry-without-resume condition alongside `isResumeFailure()`. Background-agent sessions (which `claude --resume` refuses with exit 1) now summarize via the transcript-text path instead of erroring out permanently.
- Capture the subprocess's stderr via the SDK's `stderr` callback in `callClaude` and append it to process-exit errors, so `__ERRORED__` sentinels record the actual cause (e.g. the bg-agent refusal message) instead of an opaque exit code.
- Tests: two new cases in `test/summarizer-resume-fallback.test.ts` (fallback fires on subprocess exit; stderr is appended to the surfaced error). All existing summarizer/sentinel tests pass.

An alternative considered was passing `forkSession: true` when resuming, which would keep resume-quality summaries for bg sessions — happy to switch to that if you prefer; the fallback fix is strictly more defensive (it covers any future exit-1 cause, not just bg sessions).

Note: this also surfaced a quality quirk worth a separate look — on the transcript-text path, haiku sometimes replies *to* the conversation instead of summarizing it (the `extractSummary` fallback then stores the raw reply). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)