### PR TITLE
fix: stop summarizer subprocesses from launching the user's MCP servers

### DIFF
--- a/dist/summarizer.js
+++ b/dist/summarizer.js
@@ -94,6 +94,15 @@ export function buildSummarizerQueryOptions(args) {
         env: getApiEnv(),
         resume: sessionId,
         persistSession: false,
+        // Summarizers never call tools, so skip the user's MCP config entirely.
+        // Without this, every summarization subprocess launches all configured MCP
+        // servers; with concurrent summarizations that fans out to hundreds of
+        // processes on MCP-heavy installs.
+        strictMcpConfig: true,
+        // strictMcpConfig only blocks ~/.claude.json MCP servers; user settings
+        // still load every enabled plugin (each with its own MCP server) into the
+        // subprocess. Summarizers need no plugins, hooks, or user settings at all.
+        settingSources: [],
         // Resume looks up the session under ~/.claude/projects/<encoded-cwd>/, so pass the recorded cwd when it still exists on disk.
         ...(cwd && fs.existsSync(cwd) ? { cwd } : {}),
         // Don't override systemPrompt when resuming — the resumed session's prompt stays in effect.

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -117,6 +117,15 @@ export function buildSummarizerQueryOptions(args: {
     env: getApiEnv(),
     resume: sessionId,
     persistSession: false,
+    // Summarizers never call tools, so skip the user's MCP config entirely.
+    // Without this, every summarization subprocess launches all configured MCP
+    // servers; with concurrent summarizations that fans out to hundreds of
+    // processes on MCP-heavy installs.
+    strictMcpConfig: true,
+    // strictMcpConfig only blocks ~/.claude.json MCP servers; user settings
+    // still load every enabled plugin (each with its own MCP server) into the
+    // subprocess. Summarizers need no plugins, hooks, or user settings at all.
+    settingSources: [],
     // Resume looks up the session under ~/.claude/projects/<encoded-cwd>/, so pass the recorded cwd when it still exists on disk.
     ...(cwd && fs.existsSync(cwd) ? { cwd } : {}),
     // Don't override systemPrompt when resuming — the resumed session's prompt stays in effect.

--- a/test/summarizer-options.test.ts
+++ b/test/summarizer-options.test.ts
@@ -21,6 +21,18 @@ describe('buildSummarizerQueryOptions', () => {
     expect(opts.persistSession).toBe(false);
   });
 
+  it('sets strictMcpConfig: true so summarizer subprocesses do not launch the user\'s MCP servers', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku' });
+    expect(opts.strictMcpConfig).toBe(true);
+    const resumeOpts = buildSummarizerQueryOptions({ model: 'haiku', sessionId: 'abc-123' });
+    expect(resumeOpts.strictMcpConfig).toBe(true);
+  });
+
+  it('sets settingSources: [] so summarizer subprocesses load no user settings, plugins, or hooks', () => {
+    const opts = buildSummarizerQueryOptions({ model: 'haiku' });
+    expect(opts.settingSources).toEqual([]);
+  });
+
   it('passes through the model and max_tokens', () => {
     const opts = buildSummarizerQueryOptions({ model: 'haiku' });
     expect(opts.model).toBe('haiku');


### PR DESCRIPTION
## Problem

Each summarization call spawns a Claude subprocess via the Agent SDK (`query()` in `summarizer.ts`). That subprocess inherits the user's full configuration: every MCP server in `~/.claude.json` plus all enabled plugins and their MCP servers.

On an MCP-heavy install this is brutal. My setup has ~20 configured MCP servers (several database servers, puppeteer, playwright, context7...). With 10 concurrent summarizations, the background sync fanned out to **~200 node processes** — load average 59, swap exhausted — starving everything else on the machine. It looked enough like malware that I audited it before finding the real cause. The reentrancy guard (#87) prevents the recursive cascade, but each summarizer still drags the whole MCP fleet with it.

## Fix

Summarizers only write text — they need no tools, plugins, or settings:

- `strictMcpConfig: true` → the SDK passes `--strict-mcp-config`, so the user's and project's MCP configs are ignored (no `mcpServers` are passed, so the subprocess gets none)
- `settingSources: []` → no user settings, plugins, or hooks are loaded into the subprocess

## Testing

- Two new cases in `test/summarizer-options.test.ts`; the file passes (27/27) and `tsc --noEmit` is clean
- Verified on a live install: patched summarizer subprocesses carry `--strict-mcp-config` on their command line and spawn 1 child process instead of ~7 MCP servers each; a full sync of a 370-conversation backlog ran without measurable load
- `dist/summarizer.js` rebuilt and committed per the repo convention