### PR TITLE
fix(install): verify the native binding loads instead of trusting exit codes (#100, #105)

### DIFF
--- a/cli/install-check.js
+++ b/cli/install-check.js
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 
 /**
@@ -21,8 +21,70 @@ export const REQUIRED_PACKAGES = [
   'sqlite-vec',
 ];
 
+function safeReaddir(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
 /**
- * Return the list of required packages whose package.json is missing under
+ * True when `pkg` is installed somewhere Node's resolver will find it from the
+ * plugin root: either hoisted to the top of `node_modules` (the common case)
+ * or nested one level down under the dependent that pinned it.
+ *
+ * npm nests instead of hoisting whenever a version conflict blocks the flat
+ * layout — the same mechanism behind #105 and #135. episodic-memory hits it
+ * with onnxruntime-node, which @huggingface/transformers pins to its own range
+ * and which therefore lands at
+ * `node_modules/@huggingface/transformers/node_modules/onnxruntime-node`.
+ *
+ * A top-level-only probe calls that "missing" on every single launch, so
+ * mcp-server-wrapper reruns `npm install` every time the server starts (~20s).
+ * That routinely exceeds the client's 30s MCP connect timeout, so the server
+ * the user is waiting on never becomes available.
+ *
+ * The reinstall cannot fix what the probe detects: npm already considers the
+ * tree complete and leaves the package nested, so every launch pays the cost
+ * and nothing changes. Worse, when the connect timeout kills the wrapper
+ * mid-install it can interrupt the postinstall rebuild, which is how a broken
+ * native binding (#100) survives across restarts that were supposed to repair
+ * it.
+ *
+ * The search stays inside the plugin's own node_modules on purpose: resolving
+ * via `createRequire` would also walk parent directories and Node's global
+ * folders, which could report a package as present that the plugin cannot
+ * actually load.
+ */
+function isResolvable(nodeModules, pkg) {
+  if (existsSync(join(nodeModules, pkg, 'package.json'))) {
+    return true;
+  }
+
+  for (const entry of safeReaddir(nodeModules)) {
+    if (!entry.isDirectory()) continue;
+    const entryPath = join(nodeModules, entry.name);
+
+    // Scope directories (@foo) hold packages one level deeper.
+    const dependents = entry.name.startsWith('@')
+      ? safeReaddir(entryPath)
+          .filter(d => d.isDirectory())
+          .map(d => join(entryPath, d.name))
+      : [entryPath];
+
+    for (const dependent of dependents) {
+      if (existsSync(join(dependent, 'node_modules', pkg, 'package.json'))) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Return the list of required packages that are not installed under
  * `<pluginRoot>/node_modules`. An empty array means the install looks complete;
  * a non-empty array is the diagnostic to print before re-running `npm install`.
  *
@@ -36,5 +98,5 @@ export function findMissingDeps(pluginRoot) {
   if (!existsSync(nodeModules)) {
     return REQUIRED_PACKAGES.slice();
   }
-  return REQUIRED_PACKAGES.filter(pkg => !existsSync(join(nodeModules, pkg, 'package.json')));
+  return REQUIRED_PACKAGES.filter(pkg => !isResolvable(nodeModules, pkg));
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Cross-platform postinstall: rebuild better-sqlite3's native binding against
- * the local Node version.
+ * Cross-platform postinstall: get better-sqlite3's native binding into a state
+ * where it actually loads, and refuse to report success until it does.
  *
  * Replaces the unix-only shell idiom that lived in package.json:
  *
@@ -9,32 +9,153 @@
  *
  * On Windows cmd.exe that line fails — `2>/dev/null` isn't valid redirection
  * and `|| true` doesn't behave the same — which makes `npm install` exit
- * non-zero even when every dependency installed correctly. Reporter on
- * Windows 11 (#95) saw exactly this and spent time chasing a phantom failure.
+ * non-zero even when every dependency installed correctly (#95).
  *
- * This script exits 0 on success or failure. Failure output is preserved on
- * stderr so a user (or the wrapper) can still see what went wrong, but it
- * doesn't propagate to the parent `npm install` as a fatal error.
+ * Why the exit status of `npm rebuild` cannot be trusted (#100)
+ * ------------------------------------------------------------
+ * `npm rebuild better-sqlite3` does not reliably run better-sqlite3's own
+ * install script (`prebuild-install || node-gyp rebuild --release`). On the npm
+ * shipped with recent Node it prints "rebuilt dependencies successfully",
+ * exits 0, and builds nothing. Separately, better-sqlite3 publishes prebuilds
+ * only for the Node versions in its `engines` range, so on a newer host Node
+ * `prebuild-install` can leave a binary compiled for an older ABI in place.
+ *
+ * Both failures look identical from the outside: a clean install, and a plugin
+ * whose search silently returns nothing because the MCP server dies loading the
+ * binding — in a log nobody reads.
+ *
+ * So this script does three things `status !== 0` cannot:
+ *
+ *   1. Verifies by INSTANTIATING a database, not by requiring the module.
+ *      `require('better-sqlite3')` succeeds with no binding at all, because the
+ *      addon is loaded lazily inside `new Database()` (#100).
+ *   2. Verifies in a CHILD process. A native addon cannot be un-loaded, so a
+ *      failed load poisons the module cache and an in-process re-check after a
+ *      repair attempt would be meaningless.
+ *   3. On failure, falls back to better-sqlite3's real build path
+ *      (`npm run build-release` = `node-gyp rebuild --release`) and re-verifies,
+ *      rather than printing a recovery hint naming the command that just failed.
+ *
+ * Exit code reflects the binding, not the tooling: a noisy `npm rebuild` whose
+ * binding nevertheless loads is NOT fatal (that is the #95 false alarm), and a
+ * clean `npm rebuild` that leaves an unloadable binding IS.
  */
 import { spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const BETTER_SQLITE3_DIR = join(PLUGIN_ROOT, 'node_modules', 'better-sqlite3');
 
 const isWindows = process.platform === 'win32';
 const npmBin = isWindows ? 'npm.cmd' : 'npm';
 
-const result = spawnSync(npmBin, ['rebuild', 'better-sqlite3'], {
-  stdio: ['ignore', 'inherit', 'inherit'],
-  shell: isWindows,
-});
-
-if (result.status !== 0) {
-  console.error(
-    'episodic-memory: postinstall rebuild of better-sqlite3 failed ' +
-    `(status=${result.status}). The package files are still installed, but ` +
-    'the native binding for this Node version may be missing. The MCP server ' +
-    'will surface the underlying error on first launch (see ~/.config/' +
-    'superpowers/logs/episodic-memory.log). Recover with: ' +
-    'cd <plugin-dir> && npm rebuild better-sqlite3'
-  );
+function npm(args, cwd) {
+  return spawnSync(npmBin, args, {
+    cwd,
+    stdio: ['ignore', 'inherit', 'inherit'],
+    shell: isWindows,
+  });
 }
 
-process.exit(0);
+/**
+ * Load the native stack the way the MCP server will — instantiate a database,
+ * then load sqlite-vec into it — in a throwaway child process.
+ *
+ * Returns null on success, or { stderr } describing the failure.
+ *
+ * sqlite-vec is only fatal when it is actually installed; during some install
+ * orderings it is not resolvable yet, which is a dependency problem the
+ * wrapper's own probe handles, not a native-binding problem.
+ */
+function verifyNativeStack() {
+  const pkgJson = JSON.stringify(join(PLUGIN_ROOT, 'package.json'));
+  const script = `
+    const { createRequire } = require('module');
+    const req = createRequire(${pkgJson});
+    const Database = req('better-sqlite3');
+    const db = new Database(':memory:');
+    let vec = null;
+    try { vec = req('sqlite-vec'); } catch (e) { vec = null; }
+    if (vec) { vec.load(db); db.prepare('select vec_version()').get(); }
+    db.close();
+  `;
+
+  const result = spawnSync(process.execPath, ['-e', script], {
+    cwd: PLUGIN_ROOT,
+    encoding: 'utf-8',
+  });
+
+  if (result.status === 0) return null;
+  return { stderr: (result.stderr || '').trim() || `child exited ${result.status}` };
+}
+
+// Attempt 1: the cheap path that works on most hosts.
+const rebuild = npm(['rebuild', 'better-sqlite3'], PLUGIN_ROOT);
+let failure = verifyNativeStack();
+
+// Attempt 2: better-sqlite3's real build path. `npm rebuild` frequently does
+// not run it, and it is the step that actually compiles for this Node's ABI.
+let fallback = null;
+if (failure && existsSync(BETTER_SQLITE3_DIR)) {
+  console.error(
+    'episodic-memory: better-sqlite3 binding did not load after `npm rebuild`; ' +
+    'compiling from source with `npm run build-release`...'
+  );
+  fallback = npm(['run', 'build-release'], BETTER_SQLITE3_DIR);
+  failure = verifyNativeStack();
+  if (!failure) {
+    console.error('episodic-memory: source build succeeded — native binding loads.');
+  }
+}
+
+if (!failure) {
+  if (rebuild.status !== 0 && !fallback) {
+    // Rebuild complained but the binding loads — the #95 false-alarm case.
+    console.error(
+      `episodic-memory: 'npm rebuild better-sqlite3' exited ${rebuild.status}, ` +
+      'but the native binding loads correctly for this Node ' +
+      `(${process.version}, NODE_MODULE_VERSION ${process.versions.modules}). ` +
+      'Continuing.'
+    );
+  }
+  process.exit(0);
+}
+
+const compiledFor = /NODE_MODULE_VERSION (\d+)/.exec(failure.stderr);
+const noBindings = /Could not locate the bindings file/.test(failure.stderr);
+
+console.error('');
+console.error('='.repeat(72));
+console.error('episodic-memory: NATIVE BINDING IS BROKEN — conversation search will not work.');
+console.error('='.repeat(72));
+console.error(`  this Node        : ${process.version} (NODE_MODULE_VERSION ${process.versions.modules})`);
+if (compiledFor) {
+  console.error(`  binary built for : NODE_MODULE_VERSION ${compiledFor[1]}  <-- ABI MISMATCH`);
+}
+if (noBindings) {
+  console.error('  binary           : missing entirely (nothing was compiled)');
+}
+console.error(`  npm rebuild exit : ${rebuild.status}`);
+if (fallback) {
+  console.error(`  source build exit: ${fallback.status}`);
+}
+console.error('');
+console.error('  underlying error:');
+for (const line of failure.stderr.split('\n').slice(0, 12)) {
+  console.error(`    ${line}`);
+}
+console.error('');
+console.error('  A source build needs a working toolchain: Xcode Command Line Tools on');
+console.error('  macOS, build-essential + python3 on Linux, VS Build Tools on Windows.');
+console.error('');
+console.error('  Recover with:');
+console.error(`    cd "${BETTER_SQLITE3_DIR}" && npm run build-release`);
+console.error('');
+console.error('  Failing the install deliberately: passing silently here is what lets');
+console.error('  search disappear without anyone noticing.');
+console.error('='.repeat(72));
+console.error('');
+
+process.exit(1);

--- a/test/install-check.test.ts
+++ b/test/install-check.test.ts
@@ -70,6 +70,41 @@ describe('findMissingDeps — wrapper install-health probe (#95 Bug 1)', () => {
     expect(missing).not.toContain('sqlite-vec');
   });
 
+  it('treats a package npm nested under its dependent as installed, not missing (#105)', () => {
+    const nodeModules = join(testDir, 'node_modules');
+    mkdirSync(nodeModules, { recursive: true });
+    for (const pkg of REQUIRED_PACKAGES) {
+      stagePackage(nodeModules, pkg);
+    }
+    // Reproduce the real layout: a version conflict stops npm hoisting
+    // onnxruntime-node, so it lands under @huggingface/transformers instead.
+    rmSync(join(nodeModules, 'onnxruntime-node'), { recursive: true, force: true });
+    stagePackage(
+      join(nodeModules, '@huggingface', 'transformers', 'node_modules'),
+      'onnxruntime-node'
+    );
+
+    // Node's resolver finds it there, so the wrapper must not reinstall on
+    // every launch — that reinstall is what trips the 30s MCP connect timeout.
+    expect(findMissingDeps(testDir)).toEqual([]);
+  });
+
+  it('still flags a nested package whose manifest is missing (partial extraction, one level down)', () => {
+    const nodeModules = join(testDir, 'node_modules');
+    mkdirSync(nodeModules, { recursive: true });
+    for (const pkg of REQUIRED_PACKAGES) {
+      stagePackage(nodeModules, pkg);
+    }
+    rmSync(join(nodeModules, 'onnxruntime-node'), { recursive: true, force: true });
+    // Directory exists nested, but no package.json — same damage as #95.
+    mkdirSync(
+      join(nodeModules, '@huggingface', 'transformers', 'node_modules', 'onnxruntime-node'),
+      { recursive: true }
+    );
+
+    expect(findMissingDeps(testDir)).toEqual(['onnxruntime-node']);
+  });
+
   it('does not require optional / OS-specific deps (sharp, fsevents) — those are excluded by design', () => {
     const nodeModules = join(testDir, 'node_modules');
     mkdirSync(nodeModules, { recursive: true });


### PR DESCRIPTION
Fixes #100. Addresses the probe half of #105.

Two install-path defects that each make conversation search fail silently — and that, together, keep it broken across the restarts meant to repair it.

Found on macOS arm64 / Node **v26.5.0 (NODE_MODULE_VERSION 147)** / npm 11.17.0, plugin 1.4.2 via `superpowers-marketplace`. Search had been dead for ~6 days with nothing surfaced in the UI and a clean `npm install` throughout.

---

## 1. postinstall trusted an exit code instead of the binding (#100)

`npm rebuild better-sqlite3` does not reliably run better-sqlite3's own install script, and better-sqlite3 publishes prebuilds only for the Node versions in its `engines` range (`20.x || 22.x || 23.x || 24.x || 25.x` for 12.9.0). So the rebuild can exit 0 having built nothing, or leave a binary compiled for an older ABI in place.

Here it was the ABI case — the on-disk binding was 141 while the loader required 147:

```
The module '.../better-sqlite3/build/Release/better_sqlite3.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 141. This version of Node.js requires
NODE_MODULE_VERSION 147.
```

Both failure modes look identical from outside: a clean install, and an MCP server that dies loading the binding in a log nobody reads.

**What changed**, following the direction suggested in #100:

- **Verify by instantiating, not by requiring.** `require('better-sqlite3')` succeeds with no binding at all, because the addon loads lazily inside `new Database()`. The check now opens a database and loads `sqlite-vec` into it.
- **Verify in a child process.** A native addon cannot be unloaded, so a failed load poisons the module cache — an in-process re-check after a repair attempt would be meaningless. This is what makes the fallback below verifiable at all.
- **Actually repair.** On failure it runs better-sqlite3's real build path (`npm run build-release` = `node-gyp rebuild --release`) and re-verifies, instead of printing a recovery hint naming the command that just failed.
- **Exit code reflects the binding, not the tooling.** A noisy `npm rebuild` whose binding still loads stays non-fatal — the #95 false alarm is preserved. A clean `npm rebuild` that leaves an unloadable binding now fails the install.

Failing loudly is deliberate: a plugin whose native binding will not load has no working functionality to preserve, so a silent pass is strictly worse than a failed install.

Verified by deleting the binding outright (the #100 repro) and running postinstall — it rebuilt and re-verified at ABI 147, exit 0. And against a binding that no rebuild can fix, it attempts the source build, reports both exit codes, and exits 1:

```
  this Node        : v26.5.0 (NODE_MODULE_VERSION 147)
  binary built for : NODE_MODULE_VERSION 141  <-- ABI MISMATCH
  npm rebuild exit : 0
  source build exit: 1
```

Note `npm rebuild exit: 0` — that's the hole.

> On npm 11.17.0 `npm rebuild` *does* run the install script, so #100's "silent no-op" appears npm-version-specific. The verification is what makes that difference not matter.

---

## 2. Dependency probe reported nested packages as missing (#105)

`findMissingDeps` probed only top-level `node_modules`. npm nests `onnxruntime-node` under `@huggingface/transformers` (it pins its own range), so it read as missing on **every launch**:

```
Server stderr: Missing dependencies under node_modules: onnxruntime-node
Installing episodic-memory dependencies (first run only)...
Connection failed (CONNECT_TIMEOUT): MCP server "plugin:episodic-memory:episodic-memory"
connection timed out after 30000ms
```

`mcp-server-wrapper` therefore reran a full `npm install` (~20–22s) on every start, regularly exceeding the client's 30s connect timeout — so the server the user was waiting on never became available.

**The reinstall cannot fix what the probe detects.** npm already considers the tree complete and leaves the package nested; `npm install` ran many times here and never hoisted it. Every launch paid the cost and nothing changed.

**And the two bugs interlock:** when the connect timeout kills the wrapper mid-install it can interrupt the postinstall rebuild. That is how the broken binding from §1 survived six days of restarts that each started the repair and were each killed before finishing.

The probe now also checks one level of nesting. It deliberately stays inside the plugin's own `node_modules` rather than using `createRequire().resolve()` — the latter also walks parent directories and Node's global folders, which could report a package present that the plugin cannot actually load.

**Scope note:** this fixes the *probe*, not the resolution failure in #105. `onnxruntime-common` is not in `REQUIRED_PACKAGES`, so this change does not affect it. For the packages that are, nesting under the importer is fine — `@huggingface/transformers` resolves its own nested `onnxruntime-node`, which is confirmed working here (search returns results end to end).

Cold MCP start: **22s+ and frequently timing out → 1.6s.**

---

## Testing

- Two regression tests: a nested package must read as installed; a nested package missing its manifest must still read as missing (#95's partial-extraction case, one level down). The first fails against `main` with `expected [ 'onnxruntime-node' ] to deeply equal []`.
- Full suite: **209 passed, 35 files.**
- End to end through the real MCP transport (`initialize` → `tools/list` → `tools/call search`), not just the CLI: real results against a 6,952-exchange index.
- `sqlite-vec` confirmed loading alongside (`vec_version() = v0.1.9`).

No `src/` changes, so `dist/` is untouched and needs no rebuild.

---

## Not included

Two things I noticed but left alone, happy to split out if wanted:

1. `better-sqlite3: ^12.4.1` silently resolves to a release whose `engines` excludes the host Node, and the only signal is an `EBADENGINE` warning buried in install output. A stated supported-Node range would make this a real error rather than a surprise.
2. `CLAUDE.md` orders the release as build (step 2) → bump (step 3), so `prebuild` generates `src/version.ts` from the pre-bump `package.json` and the committed `dist/` is always one version behind. On 1.4.2 the server introduces itself as `1.4.1`. Swapping steps 2 and 3 fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
