### PR TITLE
Serialize index commands with background sync

### DIFF
--- a/dist/index-cli.js
+++ b/dist/index-cli.js
@@ -4,7 +4,30 @@ import { indexSession, indexUnprocessed, indexConversations } from './indexer.js
 import { getDbPath, getArchiveDir } from './paths.js';
 import fs from 'fs';
 import path from 'path';
+import { getSyncLockPath } from './logging.js';
+import { acquireFileLock, readLockHolder, releaseFileLock } from './file-lock.js';
 const command = process.argv[2];
+// Serialize the whole CLI with `sync-cli`: every command can initialize or
+// migrate the database, and rebuild also deletes the database and summaries.
+const syncLockPath = getSyncLockPath();
+const syncLock = acquireFileLock(syncLockPath);
+if (!syncLock) {
+    const holder = readLockHolder(syncLockPath);
+    const holderLabel = holder !== null ? `pid ${holder}` : 'another process';
+    // stderr keeps this out of stdout consumers; status 0 so hooks don't fail.
+    console.error(`episodic-memory: sync already running (${holderLabel}); skipping`);
+    process.exit(0);
+}
+const releaseSyncLockOnce = () => {
+    if (releaseSyncLockOnce.done)
+        return;
+    releaseSyncLockOnce.done = true;
+    releaseFileLock(syncLock);
+};
+process.on('exit', releaseSyncLockOnce);
+process.on('SIGINT', () => { releaseSyncLockOnce(); process.exit(130); });
+process.on('SIGTERM', () => { releaseSyncLockOnce(); process.exit(143); });
+process.on('SIGHUP', () => { releaseSyncLockOnce(); process.exit(129); });
 // Parse --concurrency flag from remaining args
 function getConcurrency() {
     const concurrencyIndex = process.argv.findIndex(arg => arg === '--concurrency' || arg === '-c');

--- a/dist/logging.d.ts
+++ b/dist/logging.d.ts
@@ -1,5 +1,10 @@
 export type LogLevel = 'info' | 'warn' | 'error';
 export declare function getLogDir(): string;
 export declare function getSyncLogPath(): string;
+/**
+ * Lock shared by `sync-cli` and `index-cli`. The filename is an on-disk
+ * contract since v1.4.2: changing it lets older sync clients race new indexers.
+ */
+export declare function getSyncLockPath(): string;
 export declare function formatLogLine(level: LogLevel, message: string): string;
 export declare function appendLogLine(level: LogLevel, message: string): void;

--- a/dist/logging.js
+++ b/dist/logging.js
@@ -11,6 +11,13 @@ export function getLogDir() {
 export function getSyncLogPath() {
     return path.join(getLogDir(), 'episodic-memory.log');
 }
+/**
+ * Lock shared by `sync-cli` and `index-cli`. The filename is an on-disk
+ * contract since v1.4.2: changing it lets older sync clients race new indexers.
+ */
+export function getSyncLockPath() {
+    return path.join(getLogDir(), 'episodic-memory-sync.lock');
+}
 export function formatLogLine(level, message) {
     return `${new Date().toISOString()} [${level}] ${message}\n`;
 }

--- a/dist/sync-cli.js
+++ b/dist/sync-cli.js
@@ -6,8 +6,7 @@ import { generateExchangeEmbedding, initEmbeddings } from './embeddings.js';
 import { runMigrationBatch, countStale } from './embedding-migration.js';
 import { spawn } from 'child_process';
 import fs from 'fs';
-import path from 'path';
-import { formatLogLine, getSyncLogPath } from './logging.js';
+import { formatLogLine, getSyncLogPath, getSyncLockPath } from './logging.js';
 import { acquireFileLock, readLockHolder, releaseFileLock } from './file-lock.js';
 const args = process.argv.slice(2);
 // Reentrancy guard (#87): if this sync was triggered by a SessionStart hook
@@ -87,7 +86,7 @@ if (sourceDirs.length === 0) {
 // Windows the latter exhausts the desktop heap and crashes the workers with
 // STATUS_DLL_INIT_FAILED. Acquire after the source-dir check so help/version
 // paths don't touch the filesystem unnecessarily, and release on every exit.
-const syncLockPath = path.join(path.dirname(getSyncLogPath()), 'episodic-memory-sync.lock');
+const syncLockPath = getSyncLockPath();
 const syncLock = acquireFileLock(syncLockPath);
 if (!syncLock) {
     const holder = readLockHolder(syncLockPath);

--- a/src/index-cli.ts
+++ b/src/index-cli.ts
@@ -5,8 +5,31 @@ import { initDatabase } from './db.js';
 import { getDbPath, getArchiveDir } from './paths.js';
 import fs from 'fs';
 import path from 'path';
+import { getSyncLockPath } from './logging.js';
+import { acquireFileLock, readLockHolder, releaseFileLock } from './file-lock.js';
 
 const command = process.argv[2];
+
+// Serialize the whole CLI with `sync-cli`: every command can initialize or
+// migrate the database, and rebuild also deletes the database and summaries.
+const syncLockPath = getSyncLockPath();
+const syncLock = acquireFileLock(syncLockPath);
+if (!syncLock) {
+  const holder = readLockHolder(syncLockPath);
+  const holderLabel = holder !== null ? `pid ${holder}` : 'another process';
+  // stderr keeps this out of stdout consumers; status 0 so hooks don't fail.
+  console.error(`episodic-memory: sync already running (${holderLabel}); skipping`);
+  process.exit(0);
+}
+const releaseSyncLockOnce = () => {
+  if ((releaseSyncLockOnce as any).done) return;
+  (releaseSyncLockOnce as any).done = true;
+  releaseFileLock(syncLock);
+};
+process.on('exit', releaseSyncLockOnce);
+process.on('SIGINT', () => { releaseSyncLockOnce(); process.exit(130); });
+process.on('SIGTERM', () => { releaseSyncLockOnce(); process.exit(143); });
+process.on('SIGHUP', () => { releaseSyncLockOnce(); process.exit(129); });
 
 // Parse --concurrency flag from remaining args
 function getConcurrency(): number {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -16,6 +16,14 @@ export function getSyncLogPath(): string {
   return path.join(getLogDir(), 'episodic-memory.log');
 }
 
+/**
+ * Lock shared by `sync-cli` and `index-cli`. The filename is an on-disk
+ * contract since v1.4.2: changing it lets older sync clients race new indexers.
+ */
+export function getSyncLockPath(): string {
+  return path.join(getLogDir(), 'episodic-memory-sync.lock');
+}
+
 export function formatLogLine(level: LogLevel, message: string): string {
   return `${new Date().toISOString()} [${level}] ${message}\n`;
 }

--- a/src/sync-cli.ts
+++ b/src/sync-cli.ts
@@ -6,8 +6,7 @@ import { generateExchangeEmbedding, initEmbeddings } from './embeddings.js';
 import { runMigrationBatch, countStale } from './embedding-migration.js';
 import { spawn } from 'child_process';
 import fs from 'fs';
-import path from 'path';
-import { formatLogLine, getSyncLogPath } from './logging.js';
+import { formatLogLine, getSyncLogPath, getSyncLockPath } from './logging.js';
 import { acquireFileLock, readLockHolder, releaseFileLock } from './file-lock.js';
 
 const args = process.argv.slice(2);
@@ -97,7 +96,7 @@ if (sourceDirs.length === 0) {
 // Windows the latter exhausts the desktop heap and crashes the workers with
 // STATUS_DLL_INIT_FAILED. Acquire after the source-dir check so help/version
 // paths don't touch the filesystem unnecessarily, and release on every exit.
-const syncLockPath = path.join(path.dirname(getSyncLogPath()), 'episodic-memory-sync.lock');
+const syncLockPath = getSyncLockPath();
 const syncLock = acquireFileLock(syncLockPath);
 if (!syncLock) {
   const holder = readLockHolder(syncLockPath);

--- a/test/index-cli-single-instance.test.ts
+++ b/test/index-cli-single-instance.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { acquireFileLock, releaseFileLock, type FileLockHandle } from '../src/file-lock.js';
+
+/**
+ * index-cli and sync-cli write the same index and archive. Hold the real
+ * v1.4.2 lock and ensure index-cli exits before database work.
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const INDEX_CLI = join(REPO_ROOT, 'dist', 'index-cli.js');
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+describe('index-cli single-instance lock (#97)', () => {
+  let testDir: string;
+  let envOverrides: Record<string, string>;
+  let lockPath: string;
+  let heldLock: FileLockHandle | null = null;
+
+  function runIndexCli(args: string[]): RunResult {
+    const env = { ...process.env, ...envOverrides };
+    delete env.EPISODIC_MEMORY_DB_PATH;
+    const result = spawnSync(process.execPath, [INDEX_CLI, ...args], {
+      env,
+      timeout: 120_000,
+      encoding: 'utf-8',
+    });
+    return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+  }
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'episodic-memory-index-lock-'));
+    // Isolate all paths used by index-cli before spawning the child process.
+    mkdirSync(join(testDir, 'projects'), { recursive: true });
+    mkdirSync(join(testDir, 'archive'), { recursive: true });
+    mkdirSync(join(testDir, 'config', 'logs'), { recursive: true });
+
+    envOverrides = {
+      TEST_PROJECTS_DIR: join(testDir, 'projects'),
+      TEST_ARCHIVE_DIR: join(testDir, 'archive'),
+      TEST_DB_PATH: join(testDir, 'test.db'),
+      EPISODIC_MEMORY_CONFIG_DIR: join(testDir, 'config'),
+    };
+
+    // Pin the v1.4.2 path independently of getSyncLockPath().
+    lockPath = join(testDir, 'config', 'logs', 'episodic-memory-sync.lock');
+  });
+
+  afterEach(() => {
+    if (heldLock) {
+      releaseFileLock(heldLock);
+      heldLock = null;
+    }
+    try { rmSync(testDir, { recursive: true, force: true }); } catch {}
+  });
+
+  it('skips `index-all --no-summaries` with status 0 while the sync lock is held', () => {
+    heldLock = acquireFileLock(lockPath);
+    expect(heldLock).not.toBeNull();
+
+    const result = runIndexCli(['index-all', '--no-summaries']);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(`sync already running (pid ${process.pid}); skipping`);
+    expect(result.stdout).not.toMatch(/Initializing database/);
+    expect(existsSync(join(testDir, 'test.db'))).toBe(false);
+  });
+
+  it('skips `verify`, which can initialize and migrate the database', () => {
+    heldLock = acquireFileLock(lockPath);
+    expect(heldLock).not.toBeNull();
+
+    const result = runIndexCli(['verify']);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toMatch(/sync already running.*skipping/);
+    expect(result.stdout).not.toMatch(/Verifying conversation index/);
+    expect(existsSync(join(testDir, 'test.db'))).toBe(false);
+  });
+
+  it('releases the lock after an uncontended run', () => {
+    const result = runIndexCli(['verify']);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toMatch(/sync already running/);
+    expect(result.stdout).toMatch(/Verification Results/);
+    expect(existsSync(lockPath)).toBe(false);
+    expect(existsSync(`${lockPath}.lock`)).toBe(false);
+  });
+
+  it('releases the lock when a command exits non-zero, so a failure cannot wedge later runs', () => {
+    // Missing ID exits after the module-level lock is acquired.
+    const failed = runIndexCli(['index-session']);
+
+    expect(failed.status).toBe(1);
+    expect(failed.stderr).toMatch(/Usage: index-cli index-session <session-id>/);
+    expect(failed.stderr).not.toMatch(/sync already running/);
+    expect(existsSync(lockPath)).toBe(false);
+    expect(existsSync(`${lockPath}.lock`)).toBe(false);
+
+    const next = runIndexCli(['verify']);
+    expect(next.status).toBe(0);
+    expect(next.stderr).not.toMatch(/sync already running/);
+    expect(next.stdout).toMatch(/Verification Results/);
+  });
+});

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { formatLogLine, getLogDir, getSyncLogPath } from '../src/logging.js';
+import { formatLogLine, getLogDir, getSyncLogPath, getSyncLockPath } from '../src/logging.js';
 
 describe('diagnostic logging paths', () => {
   let testDir: string | undefined;
@@ -15,12 +15,14 @@ describe('diagnostic logging paths', () => {
     testDir = undefined;
   });
 
-  it('stores hook and background sync logs under the memory config directory', () => {
+  it('stores hook logs and the shared sync lock under the memory config directory', () => {
     testDir = mkdtempSync(join(tmpdir(), 'em-logs-'));
     process.env.EPISODIC_MEMORY_CONFIG_DIR = testDir;
 
     expect(getLogDir()).toBe(join(testDir, 'logs'));
     expect(getSyncLogPath()).toBe(join(testDir, 'logs', 'episodic-memory.log'));
+    // Pin the v1.4.2 filename so new clients still contend with installed ones.
+    expect(getSyncLockPath()).toBe(join(testDir, 'logs', 'episodic-memory-sync.lock'));
   });
 
   it('formats log lines with timestamp, level, and message', () => {


### PR DESCRIPTION
`index-cli` writes the same SQLite database and archive as `sync-cli`, but it does not acquire the v1.4.2 single-instance lock from #97. Manual indexing can therefore race a SessionStart sync.

This change moves the lock path into `getSyncLockPath()`, acquires it before any index command can initialize or rebuild the database, and releases it on normal exit, errors, and termination signals. Child-process tests cover contention and lock release after successful and failed commands.

Targeted tests pass: 6 tests across `test/index-cli-single-instance.test.ts` and `test/logging.test.ts`. The build, TypeScript check, and Semgrep pass. The full upstream suite remains blocked in this checkout by the existing `test/verify.test.ts` timestamp assertion and a `better-sqlite3` worker-teardown crash under Node 24.19.0.