### PR TITLE
feat(sync): EPISODIC_MEMORY_SKIP_SUMMARIES=1 disables the summarization pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,12 @@ export EPISODIC_MEMORY_API_TIMEOUT_MS=3000000
 
 # Override Codex binary path if needed (default: codex)
 export EPISODIC_MEMORY_CODEX_BIN=/path/to/codex
+
+# Disable the summarization pass entirely (search is unaffected)
+export EPISODIC_MEMORY_SKIP_SUMMARIES=1
 ```
+
+Only the exact value `1` disables summarization; any other value leaves it on.
 
 These settings only affect episodic-memory's summarization calls, not your interactive Claude Code or Codex sessions.
 
@@ -199,6 +204,8 @@ Codex summarization requires `codex-cli 0.130.0` or newer. If Codex app-server s
 | Embeddings | No (local Transformers.js) |
 | Search | No (local SQLite) |
 | MCP tools | No |
+
+Summaries are display-only: they decorate search results and are never embedded or searched, so `EPISODIC_MEMORY_SKIP_SUMMARIES=1` costs you that line of context and nothing else.
 
 ## Commands
 

--- a/dist/sync-cli.js
+++ b/dist/sync-cli.js
@@ -1,4 +1,4 @@
-import { syncConversations } from './sync.js';
+import { buildSyncOptionsFromEnv, syncConversations } from './sync.js';
 import { getArchiveDir, getConversationSourceDirs, getIndexDir } from './paths.js';
 import { shouldSkipReentrantSync } from './summarizer.js';
 import { initDatabase } from './db.js';
@@ -73,6 +73,7 @@ if (isBackground) {
 }
 const sourceDirs = getConversationSourceDirs();
 const destDir = getArchiveDir();
+const syncOptions = buildSyncOptionsFromEnv(process.env);
 if (sourceDirs.length === 0) {
     console.log('⚠️  No conversation source directories found.');
     console.log('  Checked: ~/.claude/projects, ~/.claude/transcripts, and ~/.codex/sessions');
@@ -111,7 +112,7 @@ console.log(`Destination: ${destDir}\n`);
 async function syncAll() {
     const totals = { copied: 0, skipped: 0, indexed: 0, summarized: 0, errors: [], sourcesWithSummaryWork: 0, totalNeedingSummaries: 0 };
     for (const sourceDir of sourceDirs) {
-        const result = await syncConversations(sourceDir, destDir);
+        const result = await syncConversations(sourceDir, destDir, syncOptions);
         totals.copied += result.copied;
         totals.skipped += result.skipped;
         totals.indexed += result.indexed;
@@ -122,7 +123,12 @@ async function syncAll() {
     console.log(`  Copied: ${totals.copied}`);
     console.log(`  Skipped: ${totals.skipped}`);
     console.log(`  Indexed: ${totals.indexed}`);
-    console.log(`  Summarized: ${totals.summarized}`);
+    if (syncOptions.skipSummaries) {
+        console.log('  Summaries: skipped (EPISODIC_MEMORY_SKIP_SUMMARIES=1)');
+    }
+    else {
+        console.log(`  Summarized: ${totals.summarized}`);
+    }
     if (totals.errors.length > 0) {
         console.log(`\n⚠️  Errors: ${totals.errors.length}`);
         totals.errors.forEach(err => console.log(`  ${err.file}: ${err.error}`));

--- a/dist/sync.d.ts
+++ b/dist/sync.d.ts
@@ -13,5 +13,21 @@ export interface SyncOptions {
     skipSummaries?: boolean;
     summaryLimit?: number;
 }
+/**
+ * Derive sync options from the process environment.
+ *
+ * `EPISODIC_MEMORY_SKIP_SUMMARIES=1` turns the summarization pass off.
+ * Only the exact string '1' enables the switch — unset, '0', 'true',
+ * and anything else leave summarization on, so a stray value can't
+ * silently disable a feature the user still expects.
+ *
+ * Why anyone wants this: summaries are display-only. search.ts reads
+ * the `-summary.txt` sidecar solely to decorate result output; summary
+ * text is never embedded and never searched, so skipping it leaves
+ * recall untouched. The summarizer, by contrast, resumes each
+ * conversation through the Claude Agent SDK, which spends the user's
+ * Claude quota and can stall on a permission prompt.
+ */
+export declare function buildSyncOptionsFromEnv(env: NodeJS.ProcessEnv): SyncOptions;
 export declare function extractSessionIdFromPath(filePath: string): string | null;
 export declare function syncConversations(sourceDir: string, destDir: string, options?: SyncOptions): Promise<SyncResult>;

--- a/dist/sync.js
+++ b/dist/sync.js
@@ -18,6 +18,24 @@ function shouldSkipConversation(filePath) {
         return false;
     }
 }
+/**
+ * Derive sync options from the process environment.
+ *
+ * `EPISODIC_MEMORY_SKIP_SUMMARIES=1` turns the summarization pass off.
+ * Only the exact string '1' enables the switch — unset, '0', 'true',
+ * and anything else leave summarization on, so a stray value can't
+ * silently disable a feature the user still expects.
+ *
+ * Why anyone wants this: summaries are display-only. search.ts reads
+ * the `-summary.txt` sidecar solely to decorate result output; summary
+ * text is never embedded and never searched, so skipping it leaves
+ * recall untouched. The summarizer, by contrast, resumes each
+ * conversation through the Claude Agent SDK, which spends the user's
+ * Claude quota and can stall on a permission prompt.
+ */
+export function buildSyncOptionsFromEnv(env) {
+    return { skipSummaries: env.EPISODIC_MEMORY_SKIP_SUMMARIES === '1' };
+}
 function copyIfNewer(src, dest) {
     // Ensure destination directory exists
     const destDir = path.dirname(dest);

--- a/src/sync-cli.ts
+++ b/src/sync-cli.ts
@@ -1,4 +1,4 @@
-import { syncConversations } from './sync.js';
+import { buildSyncOptionsFromEnv, syncConversations } from './sync.js';
 import { getArchiveDir, getConversationSourceDirs, getIndexDir } from './paths.js';
 import { shouldSkipReentrantSync } from './summarizer.js';
 import { initDatabase } from './db.js';
@@ -81,6 +81,7 @@ if (isBackground) {
 
 const sourceDirs = getConversationSourceDirs();
 const destDir = getArchiveDir();
+const syncOptions = buildSyncOptionsFromEnv(process.env);
 
 if (sourceDirs.length === 0) {
   console.log('⚠️  No conversation source directories found.');
@@ -123,7 +124,7 @@ async function syncAll() {
   const totals = { copied: 0, skipped: 0, indexed: 0, summarized: 0, errors: [] as Array<{file: string; error: string}>, sourcesWithSummaryWork: 0, totalNeedingSummaries: 0 };
 
   for (const sourceDir of sourceDirs) {
-    const result = await syncConversations(sourceDir, destDir);
+    const result = await syncConversations(sourceDir, destDir, syncOptions);
     totals.copied += result.copied;
     totals.skipped += result.skipped;
     totals.indexed += result.indexed;
@@ -135,7 +136,11 @@ async function syncAll() {
   console.log(`  Copied: ${totals.copied}`);
   console.log(`  Skipped: ${totals.skipped}`);
   console.log(`  Indexed: ${totals.indexed}`);
-  console.log(`  Summarized: ${totals.summarized}`);
+  if (syncOptions.skipSummaries) {
+    console.log('  Summaries: skipped (EPISODIC_MEMORY_SKIP_SUMMARIES=1)');
+  } else {
+    console.log(`  Summarized: ${totals.summarized}`);
+  }
 
   if (totals.errors.length > 0) {
     console.log(`\n⚠️  Errors: ${totals.errors.length}`);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -34,6 +34,25 @@ export interface SyncOptions {
   summaryLimit?: number; // Max summaries to generate per run (default: 10)
 }
 
+/**
+ * Derive sync options from the process environment.
+ *
+ * `EPISODIC_MEMORY_SKIP_SUMMARIES=1` turns the summarization pass off.
+ * Only the exact string '1' enables the switch — unset, '0', 'true',
+ * and anything else leave summarization on, so a stray value can't
+ * silently disable a feature the user still expects.
+ *
+ * Why anyone wants this: summaries are display-only. search.ts reads
+ * the `-summary.txt` sidecar solely to decorate result output; summary
+ * text is never embedded and never searched, so skipping it leaves
+ * recall untouched. The summarizer, by contrast, resumes each
+ * conversation through the Claude Agent SDK, which spends the user's
+ * Claude quota and can stall on a permission prompt.
+ */
+export function buildSyncOptionsFromEnv(env: NodeJS.ProcessEnv): SyncOptions {
+  return { skipSummaries: env.EPISODIC_MEMORY_SKIP_SUMMARIES === '1' };
+}
+
 function copyIfNewer(src: string, dest: string): boolean {
   // Ensure destination directory exists
   const destDir = path.dirname(dest);

--- a/test/sync-skip-summaries.test.ts
+++ b/test/sync-skip-summaries.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock the summarizer so the test can assert it is never reached.
+// sync.ts loads it via `await import('./summarizer.js')`, which vi.mock
+// intercepts when the mock is registered before sync is loaded.
+vi.mock('../src/summarizer.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/summarizer.js')>('../src/summarizer.js');
+  return {
+    ...actual,
+    summarizeConversation: vi.fn(),
+  };
+});
+
+import { buildSyncOptionsFromEnv, syncConversations } from '../src/sync.js';
+import { summarizeConversation } from '../src/summarizer.js';
+
+const SESSION_ID = '019b0d21-4c4e-7a11-9f3a-2c6a1e5b8d40';
+
+function makeNonEmptyJsonl(sessionId: string): string {
+  return [
+    JSON.stringify({
+      type: 'user',
+      uuid: `${sessionId}-user-1`,
+      parentUuid: null,
+      timestamp: '2025-10-01T12:00:00Z',
+      isSidechain: false,
+      cwd: '/tmp/test-cwd',
+      message: { role: 'user', content: 'How does the sync command work?' },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      uuid: `${sessionId}-asst-1`,
+      parentUuid: `${sessionId}-user-1`,
+      timestamp: '2025-10-01T12:00:01Z',
+      isSidechain: false,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'It copies, indexes, then summarizes.' }] },
+    }),
+  ].join('\n');
+}
+
+describe('buildSyncOptionsFromEnv', () => {
+  it('enables skipSummaries when EPISODIC_MEMORY_SKIP_SUMMARIES is exactly "1"', () => {
+    const options = buildSyncOptionsFromEnv({ EPISODIC_MEMORY_SKIP_SUMMARIES: '1' } as NodeJS.ProcessEnv);
+    expect(options.skipSummaries).toBe(true);
+  });
+
+  it('leaves summarization on when the variable is unset', () => {
+    expect(buildSyncOptionsFromEnv({} as NodeJS.ProcessEnv).skipSummaries).toBe(false);
+  });
+
+  it('leaves summarization on for values other than "1"', () => {
+    for (const value of ['0', 'true', 'yes', '', ' 1', '1 ']) {
+      const options = buildSyncOptionsFromEnv({ EPISODIC_MEMORY_SKIP_SUMMARIES: value } as NodeJS.ProcessEnv);
+      expect(options.skipSummaries, `value: ${JSON.stringify(value)}`).toBe(false);
+    }
+  });
+});
+
+describe('sync command — EPISODIC_MEMORY_SKIP_SUMMARIES', () => {
+  let testDir: string;
+  let sourceDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'episodic-memory-skip-summaries-test-'));
+    sourceDir = join(testDir, 'source');
+    destDir = join(testDir, 'dest');
+    mkdirSync(join(sourceDir, 'project-a'), { recursive: true });
+    writeFileSync(join(sourceDir, 'project-a', `${SESSION_ID}.jsonl`), makeNonEmptyJsonl(SESSION_ID), 'utf-8');
+    vi.mocked(summarizeConversation).mockReset();
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('writes no summary sidecar and never calls the summarizer when skipSummaries is set', async () => {
+    const options = buildSyncOptionsFromEnv({ EPISODIC_MEMORY_SKIP_SUMMARIES: '1' } as NodeJS.ProcessEnv);
+    const result = await syncConversations(sourceDir, destDir, { ...options, skipIndex: true });
+
+    expect(result.copied).toBe(1);
+    expect(result.summarized).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(vi.mocked(summarizeConversation)).not.toHaveBeenCalled();
+
+    const sidecars = readdirSync(join(destDir, 'project-a')).filter(f => f.endsWith('-summary.txt'));
+    expect(sidecars).toEqual([]);
+  });
+
+  it('still summarizes the same conversation when the variable is absent', async () => {
+    vi.mocked(summarizeConversation).mockResolvedValue('A summary of the conversation.');
+
+    const options = buildSyncOptionsFromEnv({} as NodeJS.ProcessEnv);
+    const result = await syncConversations(sourceDir, destDir, { ...options, skipIndex: true });
+
+    expect(result.summarized).toBe(1);
+    expect(vi.mocked(summarizeConversation)).toHaveBeenCalledTimes(1);
+    expect(existsSync(join(destDir, 'project-a', `${SESSION_ID}-summary.txt`))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Motivation

`episodic-memory sync` always runs the summarization pass, and there is
no way to turn it off. That pass is expensive in a way the rest of sync
is not:

- It spends the user's Claude quota. Up to 10 resume-based
  summarization calls per sync run, on every sync, forever.
- Resume-based summaries can stall on a permission prompt. Observed on
  1.4.2: of thirteen summaries in one run, two came back as text along
  the lines of "I need your approval to proceed...". For some sessions
  the resumed model continues the original conversation instead of
  summarizing it, so the sidecar ends up holding conversation text
  rather than a summary.

Search quality does not depend on any of this. `search.ts` reads the
`-summary.txt` sidecar only to decorate result output; summary text is
never embedded and never searched. So for users who want the archive
and the index but not the summarizer, the pass is pure cost.

`SyncOptions.skipSummaries` already existed and was already honored in
both the queueing and the summarizing loop — it was simply unreachable
from the CLI. This wires it to an environment variable.

## What changed

- `src/sync.ts`: new exported pure function
  `buildSyncOptionsFromEnv(env: NodeJS.ProcessEnv): SyncOptions`,
  returning `{ skipSummaries: env.EPISODIC_MEMORY_SKIP_SUMMARIES === '1' }`.
  Only the exact value `1` enables the switch, so a stray value cannot
  silently disable a feature the user still expects.
- `src/sync-cli.ts`: computes the options once and passes them to
  `syncConversations`. When the switch is on, the completion block
  prints `Summaries: skipped (EPISODIC_MEMORY_SKIP_SUMMARIES=1)` in
  place of the `Summarized:` count — a `Summarized: 0` next to a skip
  notice reads like a failure. `--background` behaviour is unchanged.
- `README.md`: the variable is documented in the API Configuration
  block, with a note that summaries are display-only.
- `dist/`: rebuilt `dist/sync.js`, `dist/sync.d.ts` and
  `dist/sync-cli.js` per CLAUDE.md's "commit `dist/` alongside `src/`".
  Two unrelated diffs that `tsc` produced were deliberately reverted so
  this PR stays scoped: `dist/version.*` (committed as 1.4.1 while
  `package.json` says 1.4.2) and the esbuild bundle
  `dist/mcp-server.js`. Both are worth a separate look.
- No `CHANGELOG.md` entry: the file has release sections only, no
  `Unreleased` convention to add to. Happy to add one under whatever
  version you want this in.

With the switch on, no `-summary.txt` is written (not even the empty
zero-exchange sentinel), the summarizer module is never imported, and
`result.summarized` stays 0. Existing sidecars are left alone, and
unsetting the variable resumes summarization where it left off.

## How tested

New `test/sync-skip-summaries.test.ts`, five tests:

- `buildSyncOptionsFromEnv` returns `skipSummaries: true` for exactly
  `'1'`.
- It returns false when the variable is unset, and for `'0'`, `'true'`,
  `'yes'`, `''`, `' 1'` and `'1 '`.
- `syncConversations` with the derived options writes no summary
  sidecar, calls no summarizer, and reports no errors. The summarizer
  is mocked the way `test/sync-error-sentinel.test.ts` mocks it.
- The negative twin: the same fixture, with options derived from an
  empty environment, does produce a sidecar and does call the
  summarizer once. Without this case the skip assertion would pass
  vacuously for a fixture that never queued a summary in the first
  place.

Full suite: 36 files, 212 tests, all passing (`vitest run`). The opt-in
`test:claude-e2e` and `test:codex-e2e` scripts were not run.

Also smoke-tested against the built `dist/sync-cli.js` with the test
path overrides pointed at a temp directory: with the variable set to
`1` the completion block prints
`Summaries: skipped (EPISODIC_MEMORY_SKIP_SUMMARIES=1)`; with it unset
it prints `Summarized: 0` as before.
