### PR TITLE
fix(summarizer): set excludeTurns on ephemeral Codex thread/fork

### DIFF
--- a/dist/summarizer.js
+++ b/dist/summarizer.js
@@ -560,6 +560,7 @@ export async function runCodexCommand(command) {
                 const fork = await send('thread/fork', {
                     threadId: command.sessionId,
                     ephemeral: true,
+                    excludeTurns: true,
                     sandbox: 'read-only',
                     approvalPolicy: 'never',
                     ...(command.model ? { model: command.model } : {}),

--- a/src/summarizer.ts
+++ b/src/summarizer.ts
@@ -640,6 +640,7 @@ export async function runCodexCommand(command: CodexSummarizerCommand): Promise<
         const fork = await send('thread/fork', {
           threadId: command.sessionId,
           ephemeral: true,
+          excludeTurns: true,
           sandbox: 'read-only',
           approvalPolicy: 'never',
           ...(command.model ? { model: command.model } : {}),

--- a/test/summarizer-options.test.ts
+++ b/test/summarizer-options.test.ts
@@ -143,6 +143,7 @@ describe('runCodexCommand', () => {
         if (message.method === 'thread/fork') {
           if (message.params.threadId !== 'session-123') throw new Error('wrong session id');
           if (message.params.ephemeral !== true) throw new Error('fork was not ephemeral');
+          if (message.params.excludeTurns !== true) throw new Error('fork did not set excludeTurns (required by codex-cli 0.150+ for paginated threads)');
           if (message.params.sandbox !== 'read-only') throw new Error('fork was not read-only');
           console.log(JSON.stringify({ id: message.id, result: { thread: { id: 'fork-456' } } }));
           return;


### PR DESCRIPTION
## Summary

`thread/fork` rejects the summarizer's ephemeral fork for any **paginated** (i.e. reasonably large) Codex thread on codex-cli 0.150+:

```
thread/fork failed: {"code":-32600,"message":"ephemeral paginated thread/fork requires `excludeTurns: true`"}
```

`summarizeConversation()` catches this and silently falls back to transcript-text summarization, so the Codex-native path stops being used for exactly the conversations it matters most for: the long ones. The only trace is a `Codex summarizer unavailable, falling back to transcript text: ...` log line — nothing surfaces as an error to the user.

## Root cause

The ephemeral `thread/fork` request in `summarizeConversation()` didn't set `excludeTurns: true`. Newer codex-cli requires it for paginated (large) threads. The flag governs pagination of the fork *response*, not the fork's context — the forked thread still carries full session history with the flag set, so summaries produced after this change remain accurate.

## Fix

Add `excludeTurns: true` to the ephemeral fork params in `src/summarizer.ts`:

```diff
         const fork = await send('thread/fork', {
           threadId: command.sessionId,
           ephemeral: true,
+          excludeTurns: true,
           sandbox: 'read-only',
           approvalPolicy: 'never',
           ...(command.model ? { model: command.model } : {}),
         });
```

`dist/summarizer.js` regenerated via `npm run build` and committed alongside `src/summarizer.ts`.

## Test plan

- [x] Extended the existing `thread/fork` mock assertion in `test/summarizer-options.test.ts` to require `excludeTurns === true`, matching the existing `ephemeral`/`sandbox` checks
- [x] `npx vitest run test/summarizer-options.test.ts` — 29/29 pass
- [x] `npm test` (full suite) — 348/348 pass, 62 test files, no regressions
- [x] `npm run build` — clean

Fixes #158.
