### PR TITLE
fix(build): allow better-sqlite3 and onnxruntime-node install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "allowScripts": {
     "better-sqlite3": true,
-    "onnxruntime-node": true
+    "onnxruntime-node": true,
+    "sharp": false
   },
   "bin": {
     "episodic-memory": "./cli/episodic-memory.js",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "./dist/*": "./dist/*",
     "./package.json": "./package.json"
   },
+  "allowScripts": {
+    "better-sqlite3": true,
+    "onnxruntime-node": true
+  },
   "bin": {
     "episodic-memory": "./cli/episodic-memory.js",
     "episodic-memory-index": "./cli/index-conversations.js",

--- a/test/allow-scripts.test.ts
+++ b/test/allow-scripts.test.ts
@@ -25,4 +25,19 @@ describe('package.json allowScripts (npm 12 install-script gating, #162)', () =>
       expect(key).not.toMatch(/@\d/);
     }
   });
+
+  it('explicitly denies sharp\'s postinstall (#102)', () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8'));
+
+    // sharp's postinstall exits 1 on any host with libvips already
+    // installed globally and corrupts node_modules on the way out (#102).
+    // It must be present here (not merely absent from allowScripts) and
+    // set to `false`, not just omitted: an omitted key blocks the script
+    // today only incidentally, and `npm install-scripts approve --all`
+    // would sweep it into the allowlist on the next run. An explicit
+    // `false` is documented to survive `--all`, turning "we happened not
+    // to allow it" into an enforced decision.
+    expect(pkg.allowScripts).toHaveProperty('sharp');
+    expect(pkg.allowScripts['sharp']).toBe(false);
+  });
 });

--- a/test/allow-scripts.test.ts
+++ b/test/allow-scripts.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const REPO_ROOT = join(import.meta.dirname, '..');
+
+describe('package.json allowScripts (npm 12 install-script gating, #162)', () => {
+  it('approves the native-binding installs indexing depends on', () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8'));
+
+    // Under npm 12 (and npm 11.16+ with blocking opted in), a dependency's
+    // install/postinstall script is skipped unless the ROOT package's
+    // allowScripts explicitly permits it. Without this, `npm install`
+    // exits 0 while better-sqlite3 and onnxruntime-node silently ship
+    // with no native binding, and indexing/search fail forever with
+    // nothing surfacing the problem to the user.
+    expect(pkg.allowScripts).toBeDefined();
+    expect(pkg.allowScripts['better-sqlite3']).toBe(true);
+    expect(pkg.allowScripts['onnxruntime-node']).toBe(true);
+
+    // Bare package names, not pinned versions: a pinned key (e.g.
+    // "better-sqlite3@12.11.1") stops matching the moment the dependency
+    // bumps, silently reintroducing the bug on the next release.
+    for (const key of Object.keys(pkg.allowScripts)) {
+      expect(key).not.toMatch(/@\d/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Under npm 12 (and npm 11.16+ with script blocking opted in), a fresh
`npm install` of the plugin skips `better-sqlite3`'s native build and
`onnxruntime-node`'s postinstall entirely, unless the root package's
`allowScripts` explicitly permits them. `npm install` still exits 0 and
prints "rebuilt dependencies successfully" — it just doesn't build
anything. Archiving keeps working, but indexing and search silently
never run again. The only trace is:

```
Error syncing: Error: Could not locate the bindings file
```

in the plugin log, which nothing surfaces to the user.

## Root cause

Neither `better-sqlite3` (needs a node-gyp/prebuild-install step) nor
`onnxruntime-node` (needs its postinstall to fetch the runtime) is
listed in `allowScripts`, so npm 12's default script-gating blocks both
on a clean install.

## Fix

Add `allowScripts` to `package.json` for the two packages indexing
depends on, keyed by bare package name (not a pinned version) so a
future dependency bump doesn't silently fall out of the allowlist and
reintroduce this bug:

```json
"allowScripts": {
  "better-sqlite3": true,
  "onnxruntime-node": true,
  "sharp": false
}
```

Also explicitly deny `sharp`'s install script rather than leaving it
absent. `sharp`'s postinstall exits 1 on any host that already has
libvips installed globally, and corrupts `node_modules` on the way out
(#102). It's been blocked so far only because it's missing from
`allowScripts` — incidental silence, not a decision — and `npm
install-scripts approve --all` would sweep an absent key into the
allowlist on its next run, since "absent" reads as "not yet reviewed"
rather than "reviewed and refused." An explicit `false` is documented
to survive `--all`, converting "we happened not to allow it" into an
enforced decision.

## Test plan

- [x] New regression test in `test/allow-scripts.test.ts`: reads
  `package.json` and asserts `allowScripts.better-sqlite3` and
  `allowScripts.onnxruntime-node` are `true`, that `allowScripts.sharp`
  is present and explicitly `false` (not merely absent), and that no
  key is a pinned `name@version` (which would stop matching on the
  next bump). Fails on `main` (`allowScripts` undefined / `sharp` key
  missing), passes with this change.
- [x] `npx vitest run test/allow-scripts.test.ts` — 2/2 pass
- [x] `npm test` (full suite) — 350/350 pass, 63 test files, no
  regressions
- [x] No `dist/` changes needed — `allowScripts` is npm-level install
  config, not bundled source.

**Scope note:** this test suite asserts the `allowScripts` config is
present and correctly shaped (right packages, right booleans, bare
names). It does not — and can't, from this environment — prove that a
fresh install under an actual npm 12 host now builds the native
bindings end-to-end. That still wants a maintainer confirming on a real
npm 12 install per the issue's repro steps.

Fixes #162.
