### PR TITLE
test(show): pin the timestamp expectation to en-US/UTC like the formatter

### DIFF
--- a/test/show.test.ts
+++ b/test/show.test.ts
@@ -230,7 +230,10 @@ describe('show command - markdown formatting', () => {
     expect(markdown).toMatch(/\*\*Agent\*\*/);
     expect(markdown).toContain('Looking at your instructions');
 
-    const expectedTimestamp = new Date('2025-09-19T17:34:29.181Z').toLocaleString();
+    // Match formatConversationAsMarkdown, which pins timestamps to en-US / UTC
+    // (#120, #130). A bare toLocaleString() depends on the host locale and
+    // timezone, so the old expectation only held on en-US / UTC hosts.
+    const expectedTimestamp = new Date('2025-09-19T17:34:29.181Z').toLocaleString('en-US', { timeZone: 'UTC' });
     expect(markdown).toContain(expectedTimestamp);
   });
 


### PR DESCRIPTION
## Problem

`formatConversationAsMarkdown` renders timestamps with `toLocaleString('en-US', { timeZone: 'UTC' })` (#120, #130), but the test in `test/show.test.ts` still builds its expectation with a bare `toLocaleString()`, i.e. the host's locale and timezone. The two only agree on en-US / UTC hosts, so the suite passes on CI and fails for anyone running it locally elsewhere:

```
Europe/Warsaw:  expected "9/19/2025, 7:34:29 PM", formatter produced "9/19/2025, 5:34:29 PM"
de_DE on UTC:   fails on the locale format
```

## Fix

Format the expectation the same way the code does. One-line test change, no runtime change.

Verified passing under `TZ=Europe/Warsaw`, `TZ=America/New_York` and `TZ=UTC`, including `LC_ALL=de_DE.UTF-8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7qt58cTm5rFNfV38EQfEN
